### PR TITLE
feat: update decrypt signature

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,25 +57,18 @@ app.post(
   },
   // Decrypt the submission
   function (req, res, next) {
-    // As the third parameter `verifiedContent` is not provided, only
-    // responses will be returned in the response object.
-    /** @type {{responses: FormField[]}} */
+    // `req.body.data` must be an object fulfilling the DecryptParams interface.
+    // interface DecryptParams {
+    //   encryptedContent: EncryptedContent
+    //   version: number
+    //   verifiedContent?: EncryptedContent
+    // }
+    /** @type {{responses: FormField[], verified?: Record<string, any>}} */
     const submission = formsg.crypto.decrypt(
       formSecretKey,
-      req.body.encryptedContent
-    )
-
-    // If a third parameter is provided, the return object will include a verified
-    // key.
-    /** @type {{
-     *    responses: FormField[],
-     *    verified: Record<string, any>
-     *  }}
-     */
-    const submission = formsg.crypto.decrypt(
-      formSecretKey,
-      req.body.encryptedContent,
-      req.body.verifiedContent
+      // If `verifiedContent` is provided in `req.body.data`, the return object
+      // will include a verified key.
+      req.body.data
     )
 
     // If the decryption failed, submission will be `null`.
@@ -107,7 +100,9 @@ The underlying cryptosystem is `x25519-xsalsa20-poly1305` which is implemented b
 
 ### Format of Decrypted Submissions
 
-`formsg.crypto.decrypt` returns an an object with the shape
+`formsg.crypto.decrypt(formSecretKey: string, decryptParams: DecryptParams)`
+takes in `decryptParams` as the second argument, and returns an an object with
+the shape
 
 <pre>
 {
@@ -116,9 +111,18 @@ The underlying cryptosystem is `x25519-xsalsa20-poly1305` which is implemented b
 }
 </pre>
 
-The `encryptedContent` field decrypts into an array of `FormField` objects, which will be assigned to the `responses` key of the returned object.
+encryptedContent: EncryptedContent
+version: number
+verifiedContent?: EncryptedContent
 
-Furthermore, if `verifiedContent` is passed as the third parameter of the `decrypt` function, the function will decrypt and open the signed decrypted content with the package's own `signingPublicKey` in [`signing-keys.ts`](https://github.com/opengovsg/formsg-javascript-sdk/tree/master/src/resource/signing-keys.ts).
+The `decryptParams.encryptedContent` field decrypts into an array of `FormField` objects, which will be assigned to the `responses` key of the returned object.
+
+Furthermore, if `decryptParams.verifiedContent` exists, the function will
+decrypt and open the signed decrypted content with the package's own
+`signingPublicKey` in
+[`signing-keys.ts`](https://github.com/opengovsg/formsg-javascript-sdk/tree/master/src/resource/signing-keys.ts).
+The resulting decrypted verifiedContent will be assigned to the `verified` key
+of the returned object.
 
 > **NOTE** <br>
 > If any errors occur, either from the failure to decrypt either `encryptedContent` or `verifiedContent`, or the failure to authenticate the decrypted signed message in `verifiedContent`, `null` will be returned.
@@ -141,12 +145,12 @@ The full schema can be viewed in
 
 If the decrypted content is the correct shape, then:
 
-1. the decrypted content will be set as the value of the `responses` key.
-2. if `verifiedContent` is passed as the third parameter, then an attempt to
+1. the decrypted content (from `decryptParams.encryptedContent`) will be set as the value of the `responses` key.
+2. if `decryptParams.verifiedContent` exists, then an attempt to
    decrypted the verified content will be called, and the result set as the
    value of `verified` key. There is no shape validation for the decrypted
    verified content. **If the verification fails, `null` is returned, even if
-   `decryptedContent` was successfully decrypted.**
+   `decryptParams.encryptedContent` was successfully decrypted.**
 
 ## Verifying Signatures Manually
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@opengovsg/formsg-sdk",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opengovsg/formsg-sdk",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/opengovsg/formsg-javascript-sdk.git"

--- a/package.json
+++ b/package.json
@@ -8,7 +8,6 @@
   "description": "Node.js SDK for integrating with FormSG",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
-  "typings": "dist/index",
   "scripts": {
     "test": "jest",
     "test:watch": "jest --watch",

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   "description": "Node.js SDK for integrating with FormSG",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
+  "typings": "dist/index",
   "scripts": {
     "test": "jest",
     "test:watch": "jest --watch",

--- a/spec/crypto.spec.ts
+++ b/spec/crypto.spec.ts
@@ -9,6 +9,8 @@ import {
 
 const formsg = formsgPackage({ mode: 'test' })
 
+const INTERNAL_TEST_VERSION = 1
+
 describe('Crypto', function () {
   const signingSecretKey = SIGNING_KEYS.test.secretKey
   const testFileBuffer = new Uint8Array(Buffer.from('./resources/ogp.svg'))
@@ -39,14 +41,22 @@ describe('Crypto', function () {
 
   it('should decrypt the submission ciphertext from 2020-03-22 successfully', () => {
     // Act
-    const decrypted = formsg.crypto.decrypt(formSecretKey, ciphertext)
+    const decrypted = formsg.crypto.decrypt(formSecretKey, {
+      encryptedContent: ciphertext,
+      version: INTERNAL_TEST_VERSION,
+    })
 
     // Assert
     expect(decrypted).toHaveProperty('responses', plaintext)
   })
 
   it('should return null on unsuccessful decryption', () => {
-    expect(formsg.crypto.decrypt('random', ciphertext)).toBe(null)
+    expect(
+      formsg.crypto.decrypt('random', {
+        encryptedContent: ciphertext,
+        version: INTERNAL_TEST_VERSION,
+      })
+    ).toBe(null)
   })
 
   it('should return null when successfully decrypted content does not fit FormField type shape', () => {
@@ -58,7 +68,12 @@ describe('Crypto', function () {
     // Assert
     // Using correct secret key, but the decrypted object should not fit the
     // expected shape and thus return null.
-    expect(formsg.crypto.decrypt(secretKey, malformedEncrypt)).toBe(null)
+    expect(
+      formsg.crypto.decrypt(secretKey, {
+        encryptedContent: malformedEncrypt,
+        version: INTERNAL_TEST_VERSION,
+      })
+    ).toBe(null)
   })
 
   it('should be able to encrypt and decrypt submissions from 2020-03-22 end-to-end successfully', () => {
@@ -67,7 +82,10 @@ describe('Crypto', function () {
 
     // Act
     const ciphertext = formsg.crypto.encrypt(plaintext, publicKey)
-    const decrypted = formsg.crypto.decrypt(secretKey, ciphertext)
+    const decrypted = formsg.crypto.decrypt(secretKey, {
+      encryptedContent: ciphertext,
+      version: INTERNAL_TEST_VERSION,
+    })
     // Assert
     expect(decrypted).toHaveProperty('responses', plaintext)
   })
@@ -79,7 +97,10 @@ describe('Crypto', function () {
     // Act
     // Signing key (last parameter) is omitted.
     const ciphertext = formsg.crypto.encrypt(plaintext, publicKey)
-    const decrypted = formsg.crypto.decrypt(secretKey, ciphertext)
+    const decrypted = formsg.crypto.decrypt(secretKey, {
+      encryptedContent: ciphertext,
+      version: INTERNAL_TEST_VERSION,
+    })
 
     // Assert
     expect(decrypted).toHaveProperty('responses', plaintext)
@@ -103,11 +124,11 @@ describe('Crypto', function () {
       signingSecretKey
     )
     // Decrypt encrypted content along with our signed+encrypted content.
-    const decrypted = formsg.crypto.decrypt(
-      secretKey,
-      ciphertext,
-      signedAndEncryptedText
-    )
+    const decrypted = formsg.crypto.decrypt(secretKey, {
+      encryptedContent: ciphertext,
+      verifiedContent: signedAndEncryptedText,
+      version: INTERNAL_TEST_VERSION,
+    })
 
     // Assert
     expect(decrypted).toHaveProperty('verified', mockVerifiedContent)

--- a/src/crypto.ts
+++ b/src/crypto.ts
@@ -9,9 +9,6 @@ import {
 import { getPublicKey } from './util/publicKey'
 import { determineIsFormFields } from './util/validate'
 
-// Validation version used in `isValid` function.
-const INTERNAL_VALIDATION_VERSION = -1
-
 /**
  * Encrypt input with a unique keypair for each submission
  * @param encryptionPublicKey The base-64 encoded public key for encrypting.
@@ -179,6 +176,8 @@ function valid(signingPublicKey: string) {
    */
   function _internalValid(publicKey: string, secretKey: string) {
     const testResponse: FormField[] = []
+    const internalValidationVersion = 1
+
     try {
       const cipherResponse = encrypt(testResponse, publicKey)
       // Use toString here since the return should be an empty array.
@@ -186,7 +185,7 @@ function valid(signingPublicKey: string) {
         testResponse.toString() ===
         decrypt(signingPublicKey)(secretKey, {
           encryptedContent: cipherResponse,
-          version: INTERNAL_VALIDATION_VERSION,
+          version: internalValidationVersion,
         })?.responses.toString()
       )
     } catch (err) {

--- a/src/crypto.ts
+++ b/src/crypto.ts
@@ -9,37 +9,8 @@ import {
 import { getPublicKey } from './util/publicKey'
 import { determineIsFormFields } from './util/validate'
 
-type DecryptParams = {
-  encryptedContent: EncryptedContent
-  version: number
-  verifiedContent?: EncryptedContent
-}
-
-// Encrypted basestring containing the submission public key,
-// nonce and encrypted data in base-64.
-// A string in the format of
-// <SubmissionPublicKey>;<Base64Nonce>:<Base64EncryptedData>
-type EncryptedContent = string
-
-type DecryptedContent = {
-  responses: FormField[]
-  verified?: Record<string, any>
-}
-
-type EncryptedFileContent = {
-  submissionPublicKey: string
-  nonce: string
-  binary: Uint8Array
-}
-
-// A base-64 encoded cryptographic keypair suitable for curve25519.
-type Keypair = {
-  publicKey: string
-  secretKey: string
-}
-
 // Validation version used in `isValid` function.
-const INTERNAL_VALIDATION_VERSION = 1
+const INTERNAL_VALIDATION_VERSION = -1
 
 /**
  * Encrypt input with a unique keypair for each submission

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,6 @@
 import webhooks from './webhooks'
 import crypto from './crypto'
 import verification from './verification'
-
 /**
  * Entrypoint into the FormSG SDK
  * @param {Object} options
@@ -22,7 +21,7 @@ export = function (options: PackageInitParams = {}) {
     }),
     verification: verification({
       mode: mode || 'production',
-      verificationOptions
-    })
+      verificationOptions,
+    }),
   }
 }

--- a/src/typings/index.d.ts
+++ b/src/typings/index.d.ts
@@ -41,7 +41,7 @@ type FormField = {
 // <SubmissionPublicKey>;<Base64Nonce>:<Base64EncryptedData>
 type EncryptedContent = string
 
-type DecryptParams = {
+interface DecryptParams {
   encryptedContent: EncryptedContent
   version: number
   verifiedContent?: EncryptedContent

--- a/src/typings/index.d.ts
+++ b/src/typings/index.d.ts
@@ -41,6 +41,12 @@ type FormField = {
 // <SubmissionPublicKey>;<Base64Nonce>:<Base64EncryptedData>
 type EncryptedContent = string
 
+type DecryptParams = {
+  encryptedContent: EncryptedContent
+  version: number
+  verifiedContent?: EncryptedContent
+}
+
 type DecryptedContent = {
   responses: FormField[]
   verified?: Record<string, any>
@@ -61,27 +67,29 @@ type Keypair = {
 type PackageMode = 'staging' | 'production' | 'development' | 'test'
 
 type VerificationOptions = {
-  secretKey?: string;
+  secretKey?: string
   transactionExpiry?: number
 }
 
 // A verified answer contains a field ID and answer
 type VerifiedAnswer = {
-  fieldId: string; 
-  answer: string;
+  fieldId: string
+  answer: string
 }
 
 // Add the transaction ID and form ID to a VerifiedAnswer to obtain a signature
 type VerificationSignatureOptions = VerifiedAnswer & {
-  transactionId: string; 
-  formId: string; 
+  transactionId: string
+  formId: string
 }
 
 // Creating a basestring requires the epoch in addition to signature requirements
-type VerificationBasestringOptions = VerificationSignatureOptions & { time: number }
+type VerificationBasestringOptions = VerificationSignatureOptions & {
+  time: number
+}
 
 // Authenticate a VerifiedAnswer with a signatureString and epoch
-type VerificationAuthenticateOptions = VerifiedAnswer & { 
-  signatureString: string; 
-  submissionCreatedAt: number; 
+type VerificationAuthenticateOptions = VerifiedAnswer & {
+  signatureString: string
+  submissionCreatedAt: number
 }

--- a/src/verification/generate-signature.ts
+++ b/src/verification/generate-signature.ts
@@ -1,16 +1,23 @@
 import nacl from 'tweetnacl'
 import { decodeUTF8, decodeBase64, encodeBase64 } from 'tweetnacl-util'
 import basestring from './basestring'
-export default function (privateKey: string){
-    
-  function generateSignature({ transactionId, formId, fieldId, answer }: VerificationSignatureOptions): string {
+
+export default function (privateKey: string) {
+  function generateSignature({
+    transactionId,
+    formId,
+    fieldId,
+    answer,
+  }: VerificationSignatureOptions): string {
     const time = Date.now()
     const data = basestring({ transactionId, formId, fieldId, answer, time })
     const signature = nacl.sign.detached(
       decodeUTF8(data),
       decodeBase64(privateKey)
     )
-    return `f=${formId},v=${transactionId},t=${time},s=${encodeBase64(signature)}`
+    return `f=${formId},v=${transactionId},t=${time},s=${encodeBase64(
+      signature
+    )}`
   }
 
   return generateSignature

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,5 +12,5 @@
     "lib": ["WebWorker"]
   },
   "include": ["src"],
-  "exclude": ["node_modules", "**/*.spec.ts, dist"]
+  "exclude": ["node_modules", "**/*.spec.ts", "dist"]
 }


### PR DESCRIPTION
# Bump package version to 0.8.0

This PR adds a breaking change to the function signature of `decrypt` to allow for better flexibility for users of the library.

## Features
BREAKING CHANGE: This is not backwards compatible with the previous versions due to change in parameter signature.

This change is to acommodate future changes in the decrypt body the library accepts for easier backwards compatibility.

## Refactor
- Rename `types` folder to `typings` so that they get exported (just typescript things)