### PR TITLE
Replace tweetnacl-util Base64 functions with StableLib

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1436,6 +1436,11 @@
         "type-detect": "4.0.8"
       }
     },
+    "@stablelib/base64": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@stablelib/base64/-/base64-1.0.0.tgz",
+      "integrity": "sha512-s/wTc/3+vYSalh4gfayJrupzhT7SDBqNtiYOeEMlkSDqL/8cExh5FAeTzLpmYq+7BLLv36EjBL5xrb0bUHWJWQ=="
+    },
     "@types/babel__core": {
       "version": "7.1.7",
       "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.1.7.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1441,6 +1441,11 @@
       "resolved": "https://registry.npmjs.org/@stablelib/base64/-/base64-1.0.0.tgz",
       "integrity": "sha512-s/wTc/3+vYSalh4gfayJrupzhT7SDBqNtiYOeEMlkSDqL/8cExh5FAeTzLpmYq+7BLLv36EjBL5xrb0bUHWJWQ=="
     },
+    "@stablelib/utf8": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@stablelib/utf8/-/utf8-1.0.0.tgz",
+      "integrity": "sha512-Y8QWrK4T0yW0HMFfSI3ZaMHKV37q27hX5ilsmKV358x01mzYfj5fwIf2LjzTlF+UIemHEXSlSN9XJnv1ML4znQ=="
+    },
     "@types/babel__core": {
       "version": "7.1.7",
       "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.1.7.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -6300,11 +6300,6 @@
       "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-1.0.3.tgz",
       "integrity": "sha512-6rt+RN7aOi1nGMyC4Xa5DdYiukl2UWCbcJft7YhxReBGQD7OAM8Pbxw6YMo4r2diNEA8FEmu32YOn9rhaiE5yw=="
     },
-    "tweetnacl-util": {
-      "version": "0.15.1",
-      "resolved": "https://registry.npmjs.org/tweetnacl-util/-/tweetnacl-util-0.15.1.tgz",
-      "integrity": "sha512-RKJBIj8lySrShN4w6i/BonWp2Z/uxwC3h4y7xsRrpP59ZboCd0GpEVsOnMDYLMmKBpYhb5TgHzZXy7wTfYFBRw=="
-    },
     "type-check": {
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
   "license": "MIT",
   "dependencies": {
     "@stablelib/base64": "^1.0.0",
+    "@stablelib/utf8": "^1.0.0",
     "tweetnacl": "^1.0.3",
     "tweetnacl-util": "^0.15.1"
   },

--- a/package.json
+++ b/package.json
@@ -24,8 +24,7 @@
   "dependencies": {
     "@stablelib/base64": "^1.0.0",
     "@stablelib/utf8": "^1.0.0",
-    "tweetnacl": "^1.0.3",
-    "tweetnacl-util": "^0.15.1"
+    "tweetnacl": "^1.0.3"
   },
   "devDependencies": {
     "@babel/cli": "^7.8.4",

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
   "author": "Open Government Products (FormSG)",
   "license": "MIT",
   "dependencies": {
+    "@stablelib/base64": "^1.0.0",
     "tweetnacl": "^1.0.3",
     "tweetnacl-util": "^0.15.1"
   },

--- a/src/crypto.ts
+++ b/src/crypto.ts
@@ -1,11 +1,9 @@
 import nacl from 'tweetnacl'
 import {
-  encodeBase64,
-  decodeBase64,
   encodeUTF8,
   decodeUTF8,
 } from 'tweetnacl-util'
-
+import { encode as encodeBase64, decode as decodeBase64 } from '@stablelib/base64'
 import { getPublicKey } from './util/publicKey'
 import { determineIsFormFields } from './util/validate'
 

--- a/src/crypto.ts
+++ b/src/crypto.ts
@@ -1,9 +1,6 @@
 import nacl from 'tweetnacl'
-import {
-  encodeUTF8,
-  decodeUTF8,
-} from 'tweetnacl-util'
 import { encode as encodeBase64, decode as decodeBase64 } from '@stablelib/base64'
+import { encode as encodeUTF8, decode as decodeUTF8 } from '@stablelib/utf8'
 import { getPublicKey } from './util/publicKey'
 import { determineIsFormFields } from './util/validate'
 
@@ -19,7 +16,7 @@ function encrypt(
   encryptionPublicKey: string,
   signingPrivateKey?: string
 ): EncryptedContent {
-  let processedMsg = decodeUTF8(JSON.stringify(msg))
+  let processedMsg = encodeUTF8(JSON.stringify(msg))
 
   if (signingPrivateKey) {
     processedMsg = nacl.sign(processedMsg, decodeBase64(signingPrivateKey))
@@ -86,7 +83,7 @@ function _verifySignedMessage(
   const openedMessage = nacl.sign.open(msg, decodeBase64(publicKey))
   if (!openedMessage)
     throw new Error('Failed to open signed message with given public key')
-  return JSON.parse(encodeUTF8(openedMessage))
+  return JSON.parse(decodeUTF8(openedMessage))
 }
 
 /**
@@ -117,7 +114,7 @@ function decrypt(signingPublicKey: string) {
       if (!decryptedContent) {
         throw new Error('Failed to decrypt content')
       }
-      const decryptedObject: Object = JSON.parse(encodeUTF8(decryptedContent))
+      const decryptedObject: Object = JSON.parse(decodeUTF8(decryptedContent))
       if (!determineIsFormFields(decryptedObject)) {
         throw new Error('Decrypted object does not fit expected shape')
       }

--- a/src/util/signature.ts
+++ b/src/util/signature.ts
@@ -1,5 +1,6 @@
 import * as tweetnacl from 'tweetnacl'
-import { decodeUTF8, encodeBase64, decodeBase64 } from 'tweetnacl-util'
+import { decodeUTF8 } from 'tweetnacl-util'
+import { encode as encodeBase64, decode as decodeBase64 } from '@stablelib/base64'
 
 /**
  * Returns a signature from a basestring and secret key

--- a/src/util/signature.ts
+++ b/src/util/signature.ts
@@ -1,5 +1,5 @@
 import * as tweetnacl from 'tweetnacl'
-import { decodeUTF8 } from 'tweetnacl-util'
+import { encode as encodeUTF8 } from '@stablelib/utf8'
 import { encode as encodeBase64, decode as decodeBase64 } from '@stablelib/base64'
 
 /**
@@ -10,7 +10,7 @@ import { encode as encodeBase64, decode as decodeBase64 } from '@stablelib/base6
  */
 function sign(basestring: string, secretKey: string): string {
   return encodeBase64(
-    tweetnacl.sign.detached(decodeUTF8(basestring), decodeBase64(secretKey))
+    tweetnacl.sign.detached(encodeUTF8(basestring), decodeBase64(secretKey))
   )
 }
 
@@ -27,7 +27,7 @@ function verify(
   publicKey: string
 ): boolean {
   return tweetnacl.sign.detached.verify(
-    decodeUTF8(message),
+    encodeUTF8(message),
     decodeBase64(signature),
     decodeBase64(publicKey)
   )

--- a/src/verification/authenticate.ts
+++ b/src/verification/authenticate.ts
@@ -1,5 +1,5 @@
 import nacl from 'tweetnacl'
-import { decodeUTF8 } from 'tweetnacl-util'
+import { encode as encodeUTF8 } from '@stablelib/utf8'
 import { decode as decodeBase64 } from '@stablelib/base64'
 import basestring from './basestring'
 
@@ -38,7 +38,7 @@ export default function ( publicKey: string, transactionExpirySeconds: number ):
       if (isSignatureTimeValid(signatureDate, submissionCreatedAt)) {
         const data = basestring({ transactionId, formId, fieldId, answer, time: signatureDate })
         return nacl.sign.detached.verify(
-          decodeUTF8(data),
+          encodeUTF8(data),
           decodeBase64(signature),
           decodeBase64(publicKey)
         )

--- a/src/verification/authenticate.ts
+++ b/src/verification/authenticate.ts
@@ -1,5 +1,6 @@
 import nacl from 'tweetnacl'
-import { decodeUTF8, decodeBase64 } from 'tweetnacl-util'
+import { decodeUTF8 } from 'tweetnacl-util'
+import { decode as decodeBase64 } from '@stablelib/base64'
 import basestring from './basestring'
 
 export default function ( publicKey: string, transactionExpirySeconds: number ): Function {

--- a/src/verification/generate-signature.ts
+++ b/src/verification/generate-signature.ts
@@ -1,5 +1,6 @@
 import nacl from 'tweetnacl'
-import { decodeUTF8, decodeBase64, encodeBase64 } from 'tweetnacl-util'
+import { decodeUTF8 } from 'tweetnacl-util'
+import { encode as encodeBase64, decode as decodeBase64 } from '@stablelib/base64'
 import basestring from './basestring'
 
 export default function (privateKey: string) {

--- a/src/verification/generate-signature.ts
+++ b/src/verification/generate-signature.ts
@@ -1,5 +1,5 @@
 import nacl from 'tweetnacl'
-import { decodeUTF8 } from 'tweetnacl-util'
+import { encode as encodeUTF8 } from '@stablelib/utf8'
 import { encode as encodeBase64, decode as decodeBase64 } from '@stablelib/base64'
 import basestring from './basestring'
 
@@ -13,7 +13,7 @@ export default function (privateKey: string) {
     const time = Date.now()
     const data = basestring({ transactionId, formId, fieldId, answer, time })
     const signature = nacl.sign.detached(
-      decodeUTF8(data),
+      encodeUTF8(data),
       decodeBase64(privateKey)
     )
     return `f=${formId},v=${transactionId},t=${time},s=${encodeBase64(


### PR DESCRIPTION
## Problem
`encode/decodeBase64` and `encode/decodeUTF8` from `tweetnacl-util` are unstable for large payloads.

Closes #26 

## Solution
Use `encode` and `decode` from StableLib instead. Note that for UTF8, all the `encode/decode` functions had to be swapped because the function signatures in StableLib are the opposite of those in tweetnacl-util.
