### PR TITLE
fix: tsc now exports declared types in the package

### DIFF
--- a/src/crypto.ts
+++ b/src/crypto.ts
@@ -1,6 +1,19 @@
 import nacl from 'tweetnacl'
-import { encode as encodeBase64, decode as decodeBase64 } from '@stablelib/base64'
+import {
+  encode as encodeBase64,
+  decode as decodeBase64,
+} from '@stablelib/base64'
 import { encode as encodeUTF8, decode as decodeUTF8 } from '@stablelib/utf8'
+
+import {
+  DecryptParams,
+  DecryptedContent,
+  EncryptedContent,
+  EncryptedFileContent,
+  FormField,
+  Keypair,
+  PackageInitParams,
+} from './types'
 import { getPublicKey } from './util/publicKey'
 import { determineIsFormFields } from './util/validate'
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,7 @@
-import webhooks from './webhooks'
 import crypto from './crypto'
+import { PackageInitParams } from './types'
 import verification from './verification'
+import webhooks from './webhooks'
 /**
  * Entrypoint into the FormSG SDK
  * @param {Object} options

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,11 +1,11 @@
-type PackageInitParams = {
+export type PackageInitParams = {
   mode?: PackageMode
   webhookSecretKey?: string
   verificationOptions?: VerificationOptions
 }
 
 // A field type available in FormSG as a string
-type FieldType =
+export type FieldType =
   | 'section'
   | 'radiobutton'
   | 'dropdown'
@@ -24,7 +24,7 @@ type FieldType =
   | 'mobile'
 
 // Represents form field responses in a form.
-type FormField = {
+export type FormField = {
   _id: string
   question: string
   fieldType: FieldType
@@ -39,57 +39,57 @@ type FormField = {
 // nonce and encrypted data in base-64.
 // A string in the format of
 // <SubmissionPublicKey>;<Base64Nonce>:<Base64EncryptedData>
-type EncryptedContent = string
+export type EncryptedContent = string
 
-interface DecryptParams {
+export interface DecryptParams {
   encryptedContent: EncryptedContent
   version: number
   verifiedContent?: EncryptedContent
 }
 
-type DecryptedContent = {
+export type DecryptedContent = {
   responses: FormField[]
   verified?: Record<string, any>
 }
 
-type EncryptedFileContent = {
+export type EncryptedFileContent = {
   submissionPublicKey: string
   nonce: string
   binary: Uint8Array
 }
 
 // A base-64 encoded cryptographic keypair suitable for curve25519.
-type Keypair = {
+export type Keypair = {
   publicKey: string
   secretKey: string
 }
 
-type PackageMode = 'staging' | 'production' | 'development' | 'test'
+export type PackageMode = 'staging' | 'production' | 'development' | 'test'
 
-type VerificationOptions = {
+export type VerificationOptions = {
   secretKey?: string
   transactionExpiry?: number
 }
 
 // A verified answer contains a field ID and answer
-type VerifiedAnswer = {
+export type VerifiedAnswer = {
   fieldId: string
   answer: string
 }
 
 // Add the transaction ID and form ID to a VerifiedAnswer to obtain a signature
-type VerificationSignatureOptions = VerifiedAnswer & {
+export type VerificationSignatureOptions = VerifiedAnswer & {
   transactionId: string
   formId: string
 }
 
 // Creating a basestring requires the epoch in addition to signature requirements
-type VerificationBasestringOptions = VerificationSignatureOptions & {
+export type VerificationBasestringOptions = VerificationSignatureOptions & {
   time: number
 }
 
 // Authenticate a VerifiedAnswer with a signatureString and epoch
-type VerificationAuthenticateOptions = VerifiedAnswer & {
+export type VerificationAuthenticateOptions = VerifiedAnswer & {
   signatureString: string
   submissionCreatedAt: number
 }

--- a/src/util/publicKey.ts
+++ b/src/util/publicKey.ts
@@ -1,4 +1,6 @@
 import { SIGNING_KEYS } from '../resource/signing-keys'
+import { PackageMode } from '../types'
+
 import STAGE from './stage'
 
 /**

--- a/src/util/stage.ts
+++ b/src/util/stage.ts
@@ -1,3 +1,5 @@
+import { PackageMode } from '../types'
+
 const STAGE: { [stage in PackageMode]: stage } = {
   staging: 'staging',
   production: 'production',

--- a/src/util/validate.ts
+++ b/src/util/validate.ts
@@ -1,3 +1,5 @@
+import { FormField } from '../types'
+
 function determineIsFormFields(tbd: any): tbd is FormField[] {
   if (!Array.isArray(tbd)) {
     return false

--- a/src/verification/authenticate.ts
+++ b/src/verification/authenticate.ts
@@ -1,49 +1,75 @@
 import nacl from 'tweetnacl'
 import { encode as encodeUTF8 } from '@stablelib/utf8'
 import { decode as decodeBase64 } from '@stablelib/base64'
+
+import { VerificationAuthenticateOptions } from '../types'
 import basestring from './basestring'
 
-export default function ( publicKey: string, transactionExpirySeconds: number ): Function {
+export default function (
+  publicKey: string,
+  transactionExpirySeconds: number
+): Function {
   /*
-    *  Checks if signature was made within TRANSACTION_EXPIRE_AFTER_SECONDS before submission was created
-    * @param {Number} signatureTime ms
-    * @param {Number} submissionCreatedAt ms
-    */
-  function isSignatureTimeValid(signatureTime: number, submissionCreatedAt: number): boolean {
+   *  Checks if signature was made within TRANSACTION_EXPIRE_AFTER_SECONDS before submission was created
+   * @param {Number} signatureTime ms
+   * @param {Number} submissionCreatedAt ms
+   */
+  function isSignatureTimeValid(
+    signatureTime: number,
+    submissionCreatedAt: number
+  ): boolean {
     const maxTime = submissionCreatedAt
     const minTime = maxTime - transactionExpirySeconds * 1000
     return signatureTime > minTime && signatureTime < maxTime
   }
 
   /**
-     *  Verifies signature
-     * @param {object} data
-     * @param {string} data.signatureString
-     * @param {number} data.submissionCreatedAt date in milliseconds
-     * @param {string} data.fieldId
-     * @param {string} data.answer
-     * @param {string} data.publicKey
-     */
-  function authenticate({ signatureString, submissionCreatedAt, fieldId, answer }: VerificationAuthenticateOptions) {
+   *  Verifies signature
+   * @param {object} data
+   * @param {string} data.signatureString
+   * @param {number} data.submissionCreatedAt date in milliseconds
+   * @param {string} data.fieldId
+   * @param {string} data.answer
+   * @param {string} data.publicKey
+   */
+  function authenticate({
+    signatureString,
+    submissionCreatedAt,
+    fieldId,
+    answer,
+  }: VerificationAuthenticateOptions) {
     try {
-      const { v: transactionId, t: time, f: formId, s: signature } = signatureString
+      const {
+        v: transactionId,
+        t: time,
+        f: formId,
+        s: signature,
+      } = signatureString
         .split(',')
-        .reduce(function (acc: {[key: string]: string}, v: string){
+        .reduce(function (acc: { [key: string]: string }, v: string) {
           const i = v.indexOf('=')
           acc[v.substring(0, i)] = v.substring(i + 1)
           return acc
         }, {})
-    
+
       const signatureDate = +time
       if (isSignatureTimeValid(signatureDate, submissionCreatedAt)) {
-        const data = basestring({ transactionId, formId, fieldId, answer, time: signatureDate })
+        const data = basestring({
+          transactionId,
+          formId,
+          fieldId,
+          answer,
+          time: signatureDate,
+        })
         return nacl.sign.detached.verify(
           encodeUTF8(data),
           decodeBase64(signature),
           decodeBase64(publicKey)
         )
       } else {
-        console.info(`Signature was expired for signatureString="${signatureString}" signatureDate="${signatureDate}" submissionCreatedAt="${submissionCreatedAt}"`)
+        console.info(
+          `Signature was expired for signatureString="${signatureString}" signatureDate="${signatureDate}" submissionCreatedAt="${submissionCreatedAt}"`
+        )
         return false
       }
     } catch (error) {

--- a/src/verification/basestring.ts
+++ b/src/verification/basestring.ts
@@ -1,11 +1,16 @@
+import { VerificationBasestringOptions } from '../types'
 
 /**
  * Formats given data into a string for signing
  */
-function basestring(
-  { transactionId, formId, fieldId, answer, time }: VerificationBasestringOptions
-): string {
+function basestring({
+  transactionId,
+  formId,
+  fieldId,
+  answer,
+  time,
+}: VerificationBasestringOptions): string {
   return `${transactionId}.${formId}.${fieldId}.${answer}.${time}`
 }
-  
+
 export default basestring

--- a/src/verification/generate-signature.ts
+++ b/src/verification/generate-signature.ts
@@ -1,6 +1,11 @@
 import nacl from 'tweetnacl'
 import { encode as encodeUTF8 } from '@stablelib/utf8'
-import { encode as encodeBase64, decode as decodeBase64 } from '@stablelib/base64'
+import {
+  encode as encodeBase64,
+  decode as decodeBase64,
+} from '@stablelib/base64'
+
+import { VerificationSignatureOptions } from '../types'
 import basestring from './basestring'
 
 export default function (privateKey: string) {

--- a/src/verification/get-public-key.ts
+++ b/src/verification/get-public-key.ts
@@ -1,4 +1,5 @@
 import { VERIFICATION_KEYS } from '../resource/verification-keys'
+import { PackageMode } from '../types'
 import STAGE from '../util/stage'
 
 /**
@@ -8,13 +9,13 @@ import STAGE from '../util/stage'
  */
 function getPublicKey(mode?: PackageMode) {
   switch (mode) {
-  case STAGE.development:
-  case STAGE.staging:
-    return VERIFICATION_KEYS.staging.publicKey
-  case STAGE.test:
-    return VERIFICATION_KEYS.test.publicKey
-  default:
-    return VERIFICATION_KEYS.production.publicKey
+    case STAGE.development:
+    case STAGE.staging:
+      return VERIFICATION_KEYS.staging.publicKey
+    case STAGE.test:
+      return VERIFICATION_KEYS.test.publicKey
+    default:
+      return VERIFICATION_KEYS.production.publicKey
   }
 }
 

--- a/src/verification/index.ts
+++ b/src/verification/index.ts
@@ -1,7 +1,8 @@
 /**
  * @file Manages verification of otp form fields (email, sms, whatsapp)
- * @author Jean Tan 
+ * @author Jean Tan
  */
+import { PackageInitParams } from '../types'
 
 import authenticate from './authenticate'
 import generateSignature from './generate-signature'
@@ -13,18 +14,30 @@ import getPublicKey from './get-public-key'
  */
 export = function (params: PackageInitParams = {}) {
   const { mode, verificationOptions } = params
-  if(verificationOptions !== undefined){
+  if (verificationOptions !== undefined) {
     const verificationPublicKey = getPublicKey(mode)
-    const { secretKey: verificationSecretKey, transactionExpiry } = verificationOptions
-    return { 
-      authenticate: transactionExpiry !== undefined ? 
-        authenticate(verificationPublicKey, transactionExpiry)
-        : function (){ throw new Error('Provide transactionExpiry when initializing the formsg sdk to use this function.') },
-      generateSignature: verificationSecretKey !== undefined ?
-        generateSignature(verificationSecretKey)
-        : function (){ throw new Error('Provide verificationSecretKey when initializing the formsg sdk to use this function.')  },
+    const {
+      secretKey: verificationSecretKey,
+      transactionExpiry,
+    } = verificationOptions
+    return {
+      authenticate:
+        transactionExpiry !== undefined
+          ? authenticate(verificationPublicKey, transactionExpiry)
+          : function () {
+              throw new Error(
+                'Provide transactionExpiry when initializing the formsg sdk to use this function.'
+              )
+            },
+      generateSignature:
+        verificationSecretKey !== undefined
+          ? generateSignature(verificationSecretKey)
+          : function () {
+              throw new Error(
+                'Provide verificationSecretKey when initializing the formsg sdk to use this function.'
+              )
+            },
     }
   }
   return {}
 }
-  

--- a/src/webhooks.ts
+++ b/src/webhooks.ts
@@ -1,5 +1,6 @@
 import * as url from 'url'
 
+import { PackageInitParams } from './types'
 import { sign, verify } from './util/signature'
 import { getPublicKey } from './util/publicKey'
 import { parseSignatureHeader } from './util/parser'


### PR DESCRIPTION
The package was not exporting types in the package due to typings being kept in a `*.d.ts` file, which does not get exported when publishing the package to npm, resulting to developers not getting the correct types anyways.

This PR fixes that by adding a `types.ts` file which exports all the current types of the package. 