### PR TITLE
chore: add `test-ci` script for Travis to run instead of `test`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,5 +15,5 @@ before_script:
   - npm install
 
 script:
-  - npm test
+  - npm test-ci
   - npm build

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,5 +15,5 @@ before_script:
   - npm install
 
 script:
-  - npm test-ci
+  - npm run test-ci
   - npm build

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "scripts": {
+    "test": "jest",
     "test-ci": "jest --coverage && coveralls < coverage/lcov.info && rm -rf ./coverage",
     "test:watch": "jest --watch",
     "build": "tsc",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "scripts": {
-    "test": "jest --coverage && coveralls < coverage/lcov.info && rm -rf ./coverage",
+    "test-ci": "jest --coverage && coveralls < coverage/lcov.info && rm -rf ./coverage",
     "test:watch": "jest --watch",
     "build": "tsc",
     "prepare": "npm run build"


### PR DESCRIPTION
Current `test` script may not be as useful for local devs since they might not have coveralls installed, resulting in an error (and undeleted `.coverage` folder):

![Screenshot 2020-06-04 at 1 36 46 PM](https://user-images.githubusercontent.com/22133008/83718864-705a5800-a668-11ea-85e5-c9d7567010dd.png)

## Improvements
This PR:
- renames the `test` script to `test-ci` and points Travis to run the script
- adds back the old simpler `test` script for local test runs