### PR TITLE
feat: add publicKey param to package initialization parameters

### DIFF
--- a/src/crypto.ts
+++ b/src/crypto.ts
@@ -255,8 +255,8 @@ async function decryptFile(
  * Provider that accepts configuration before returning the crypto module to
  * init.
  */
-export = function ({ mode }: Omit<PackageInitParams, 'webhookSecretKey'>) {
-  const signingPublicKey = getPublicKey(mode)
+export = function ({ mode, publicKey }: PackageInitParams) {
+  const signingPublicKey = publicKey || getPublicKey(mode || 'production')
   return {
     encrypt,
     decrypt: decrypt(signingPublicKey),

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,19 +10,9 @@ import webhooks from './webhooks'
  * @param {string?} [config.webhookSecretKey] Optional base64 secret key for signing webhooks
  */
 export = function (config: PackageInitParams = {}) {
-  const { mode, publicKey, webhookSecretKey, verificationOptions } = config
-
   return {
-    webhooks: webhooks({
-      mode: mode || 'production',
-      webhookSecretKey,
-    }),
-    crypto: crypto({
-      mode: mode || 'production',
-    }),
-    verification: verification({
-      mode: mode || 'production',
-      verificationOptions,
-    }),
+    webhooks: webhooks(config),
+    crypto: crypto(config),
+    verification: verification(config),
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,13 +4,13 @@ import verification from './verification'
 import webhooks from './webhooks'
 /**
  * Entrypoint into the FormSG SDK
- * @param {Object} options
- * @param {string} [options.mode] If set to 'staging' this will initialise
- * the SDK for the FormSG staging environment
- * @param {string} [options.webhookSecretKey] Optional base64 secret key for signing webhooks
+ * @param {PackageInitParams} config Package initialization config parameters
+ * @param {string?} [config.publicKey] Optional. If provided, this public key will be used instead to authenticate or verify signed objects passed into this package.
+ * @param {string?} [config.mode] Optional. Initializes public key used for verifying and decrypting in this package. If `config.signingPublicKey` is given, this param will be ignored.
+ * @param {string?} [config.webhookSecretKey] Optional base64 secret key for signing webhooks
  */
-export = function (options: PackageInitParams = {}) {
-  const { mode, webhookSecretKey, verificationOptions } = options
+export = function (config: PackageInitParams = {}) {
+  const { mode, publicKey, webhookSecretKey, verificationOptions } = config
 
   return {
     webhooks: webhooks({

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,8 +1,10 @@
 export type PackageInitParams = {
-  mode?: PackageMode
   webhookSecretKey?: string
   verificationOptions?: VerificationOptions
-}
+} & (
+  | { publicKey?: string; mode?: never }
+  | { publicKey?: never; mode?: PackageMode }
+)
 
 // A field type available in FormSG as a string
 export type FieldType =

--- a/src/types.ts
+++ b/src/types.ts
@@ -24,6 +24,7 @@ export type FieldType =
   | 'attachment'
   | 'date'
   | 'mobile'
+  | 'homeno'
 
 // Represents form field responses in a form.
 export type FormField = {

--- a/src/verification/index.ts
+++ b/src/verification/index.ts
@@ -12,10 +12,14 @@ import getPublicKey from './get-public-key'
  * Provider that accepts configuration
  * before returning the webhooks module
  */
-export = function (params: PackageInitParams = {}) {
-  const { mode, verificationOptions } = params
+export = function ({
+  mode,
+  verificationOptions,
+  publicKey,
+}: PackageInitParams) {
   if (verificationOptions !== undefined) {
-    const verificationPublicKey = getPublicKey(mode)
+    const verificationPublicKey =
+      publicKey || getPublicKey(mode || 'production')
     const {
       secretKey: verificationSecretKey,
       transactionExpiry,

--- a/src/webhooks.ts
+++ b/src/webhooks.ts
@@ -150,9 +150,8 @@ function constructHeader({
  * Provider that accepts configuration
  * before returning the webhooks module
  */
-export = function (params: PackageInitParams = {}) {
-  const { mode, webhookSecretKey } = params
-  const webhookPublicKey = getPublicKey(mode)
+export = function ({ mode, webhookSecretKey, publicKey }: PackageInitParams) {
+  const webhookPublicKey = publicKey || getPublicKey(mode || 'production')
 
   return {
     /* Verification functions */


### PR DESCRIPTION
(I don't know why I named my branch the way I named it)

This PR adds a `publicKey` key option for the initialisation parameter for this package.
If the `publicKey` key is given, then all signing, webhook, and verification keys will be using the given public key instead of the package fallback keys.

Closes #30 