### PR TITLE
refactor: update crypto HOF to Crypto class

### DIFF
--- a/spec/crypto.spec.ts
+++ b/spec/crypto.spec.ts
@@ -226,7 +226,6 @@ describe('Crypto', function () {
     // Act + Assert
     const decryptResult = crypto.decrypt(secretKey, {
       encryptedContent: ciphertext,
-      // Verified content is signed with a different public signing key.
       verifiedContent: rubbishVerifiedContent,
       version: INTERNAL_TEST_VERSION,
     })

--- a/spec/crypto.spec.ts
+++ b/spec/crypto.spec.ts
@@ -16,7 +16,7 @@ const signingSecretKey = SIGNING_KEYS.test.secretKey
 const testFileBuffer = new Uint8Array(Buffer.from('./resources/ogp.svg'))
 
 describe('Crypto', function () {
-  const crypto = new Crypto({ publicKey: encryptionPublicKey })
+  const crypto = new Crypto({ publicSigningKey: encryptionPublicKey })
 
   it('should generate a keypair', () => {
     const keypair = crypto.generate()

--- a/spec/crypto.spec.ts
+++ b/spec/crypto.spec.ts
@@ -1,49 +1,50 @@
+import Crypto from '../src/crypto'
 import { SIGNING_KEYS } from '../src/resource/signing-keys'
-import formsgPackage from '../src/index'
+
 import {
   plaintext,
   ciphertext,
   formSecretKey,
   formPublicKey,
 } from './resources/crypto-data-20200322'
-
 import { plaintextMultiLang } from './resources/crypto-data-20200604'
-
-const formsg = formsgPackage({ mode: 'test' })
 
 const INTERNAL_TEST_VERSION = 1
 
+const encryptionPublicKey = SIGNING_KEYS.test.publicKey
+const signingSecretKey = SIGNING_KEYS.test.secretKey
+const testFileBuffer = new Uint8Array(Buffer.from('./resources/ogp.svg'))
+
 describe('Crypto', function () {
-  const signingSecretKey = SIGNING_KEYS.test.secretKey
-  const testFileBuffer = new Uint8Array(Buffer.from('./resources/ogp.svg'))
+  const crypto = new Crypto({ publicKey: encryptionPublicKey })
 
   it('should generate a keypair', () => {
-    const keypair = formsg.crypto.generate()
-    expect(Object.keys(keypair)).toContain('secretKey')
-    expect(Object.keys(keypair)).toContain('publicKey')
+    const keypair = crypto.generate()
+    expect(keypair).toHaveProperty('secretKey')
+    expect(keypair).toHaveProperty('publicKey')
   })
 
   it('should generate a keypair that is valid', () => {
-    const { publicKey, secretKey } = formsg.crypto.generate()
-    expect(formsg.crypto.valid(publicKey, secretKey)).toBe(true)
+    const { publicKey, secretKey } = crypto.generate()
+    expect(crypto.valid(publicKey, secretKey)).toBe(true)
   })
 
   it('should validate an existing keypair', () => {
-    expect(formsg.crypto.valid(formPublicKey, formSecretKey)).toBe(true)
+    expect(crypto.valid(formPublicKey, formSecretKey)).toBe(true)
   })
 
   it('should invalidate unassociated keypairs', () => {
     // Act
-    const { secretKey } = formsg.crypto.generate()
-    const { publicKey } = formsg.crypto.generate()
+    const { secretKey } = crypto.generate()
+    const { publicKey } = crypto.generate()
 
     // Assert
-    expect(formsg.crypto.valid(publicKey, secretKey)).toBe(false)
+    expect(crypto.valid(publicKey, secretKey)).toBe(false)
   })
 
   it('should decrypt the submission ciphertext from 2020-03-22 successfully', () => {
     // Act
-    const decrypted = formsg.crypto.decrypt(formSecretKey, {
+    const decrypted = crypto.decrypt(formSecretKey, {
       encryptedContent: ciphertext,
       version: INTERNAL_TEST_VERSION,
     })
@@ -54,7 +55,7 @@ describe('Crypto', function () {
 
   it('should return null on unsuccessful decryption', () => {
     expect(
-      formsg.crypto.decrypt('random', {
+      crypto.decrypt('random', {
         encryptedContent: ciphertext,
         version: INTERNAL_TEST_VERSION,
       })
@@ -63,15 +64,15 @@ describe('Crypto', function () {
 
   it('should return null when successfully decrypted content does not fit FormField type shape', () => {
     // Arrange
-    const { publicKey, secretKey } = formsg.crypto.generate()
+    const { publicKey, secretKey } = crypto.generate()
     const malformedContent = 'just a string, not an object with FormField shape'
-    const malformedEncrypt = formsg.crypto.encrypt(malformedContent, publicKey)
+    const malformedEncrypt = crypto.encrypt(malformedContent, publicKey)
 
     // Assert
     // Using correct secret key, but the decrypted object should not fit the
     // expected shape and thus return null.
     expect(
-      formsg.crypto.decrypt(secretKey, {
+      crypto.decrypt(secretKey, {
         encryptedContent: malformedEncrypt,
         version: INTERNAL_TEST_VERSION,
       })
@@ -80,11 +81,11 @@ describe('Crypto', function () {
 
   it('should be able to encrypt and decrypt submissions from 2020-03-22 end-to-end successfully', () => {
     // Arrange
-    const { publicKey, secretKey } = formsg.crypto.generate()
+    const { publicKey, secretKey } = crypto.generate()
 
     // Act
-    const ciphertext = formsg.crypto.encrypt(plaintext, publicKey)
-    const decrypted = formsg.crypto.decrypt(secretKey, {
+    const ciphertext = crypto.encrypt(plaintext, publicKey)
+    const decrypted = crypto.decrypt(secretKey, {
       encryptedContent: ciphertext,
       version: INTERNAL_TEST_VERSION,
     })
@@ -94,11 +95,11 @@ describe('Crypto', function () {
 
   it('should be able to encrypt and decrypt multi-language submission from 2020-06-04 end-to-end successfully', () => {
     // Arrange
-    const { publicKey, secretKey } = formsg.crypto.generate()
+    const { publicKey, secretKey } = crypto.generate()
 
     // Act
-    const ciphertext = formsg.crypto.encrypt(plaintextMultiLang, publicKey)
-    const decrypted = formsg.crypto.decrypt(secretKey, {
+    const ciphertext = crypto.encrypt(plaintextMultiLang, publicKey)
+    const decrypted = crypto.decrypt(secretKey, {
       encryptedContent: ciphertext,
       version: INTERNAL_TEST_VERSION,
     })
@@ -108,12 +109,12 @@ describe('Crypto', function () {
 
   it('should be able to encrypt submissions without signing if signingPrivateKey is missing', () => {
     // Arrange
-    const { publicKey, secretKey } = formsg.crypto.generate()
+    const { publicKey, secretKey } = crypto.generate()
 
     // Act
     // Signing key (last parameter) is omitted.
-    const ciphertext = formsg.crypto.encrypt(plaintext, publicKey)
-    const decrypted = formsg.crypto.decrypt(secretKey, {
+    const ciphertext = crypto.encrypt(plaintext, publicKey)
+    const decrypted = crypto.decrypt(secretKey, {
       encryptedContent: ciphertext,
       version: INTERNAL_TEST_VERSION,
     })
@@ -124,7 +125,7 @@ describe('Crypto', function () {
 
   it('should be able to encrypt and sign submissions if signingPrivateKey is given', () => {
     // Arrange
-    const { publicKey, secretKey } = formsg.crypto.generate()
+    const { publicKey, secretKey } = crypto.generate()
     const mockVerifiedContent = {
       uinFin: 'S12345679Z',
       somethingElse: 99,
@@ -132,15 +133,15 @@ describe('Crypto', function () {
 
     // Act
     // Encrypt content that is not signed.
-    const ciphertext = formsg.crypto.encrypt(plaintext, publicKey)
+    const ciphertext = crypto.encrypt(plaintext, publicKey)
     // Sign and encrypt the desired content.
-    const signedAndEncryptedText = formsg.crypto.encrypt(
+    const signedAndEncryptedText = crypto.encrypt(
       mockVerifiedContent,
       publicKey,
       signingSecretKey
     )
     // Decrypt encrypted content along with our signed+encrypted content.
-    const decrypted = formsg.crypto.decrypt(secretKey, {
+    const decrypted = crypto.decrypt(secretKey, {
       encryptedContent: ciphertext,
       verifiedContent: signedAndEncryptedText,
       version: INTERNAL_TEST_VERSION,
@@ -153,17 +154,17 @@ describe('Crypto', function () {
 
   it('should be able to encrypt and decrypt files end-to-end', async () => {
     // Arrange
-    const { publicKey, secretKey } = formsg.crypto.generate()
+    const { publicKey, secretKey } = crypto.generate()
 
     // Act
     // Encrypt
-    const encrypted = await formsg.crypto.encryptFile(testFileBuffer, publicKey)
+    const encrypted = await crypto.encryptFile(testFileBuffer, publicKey)
     expect(encrypted).toHaveProperty('submissionPublicKey')
     expect(encrypted).toHaveProperty('nonce')
     expect(encrypted).toHaveProperty('binary')
 
     // Decrypt
-    const decrypted = await formsg.crypto.decryptFile(secretKey, encrypted)
+    const decrypted = await crypto.decryptFile(secretKey, encrypted)
 
     if (!decrypted) {
       throw new Error('File should be able to decrypt successfully.')
@@ -174,13 +175,13 @@ describe('Crypto', function () {
   })
 
   it('should return null if file could not be decrypted', async () => {
-    const { publicKey, secretKey } = formsg.crypto.generate()
+    const { publicKey, secretKey } = crypto.generate()
 
-    const encrypted = await formsg.crypto.encryptFile(testFileBuffer, publicKey)
+    const encrypted = await crypto.encryptFile(testFileBuffer, publicKey)
     // Rewrite binary with invalid Uint8Array.
     encrypted.binary = new Uint8Array([1, 2])
 
-    const decrypted = await formsg.crypto.decryptFile(secretKey, encrypted)
+    const decrypted = await crypto.decryptFile(secretKey, encrypted)
 
     expect(decrypted).toBeNull()
   })

--- a/src/crypto.ts
+++ b/src/crypto.ts
@@ -6,8 +6,6 @@ import {
   EncryptedContent,
   EncryptedFileContent,
   FormField,
-  Keypair,
-  PackageInitParams,
 } from './types'
 
 import {
@@ -17,97 +15,42 @@ import {
   decodeUTF8,
 } from 'tweetnacl-util'
 
-import { getPublicKey } from './util/publicKey'
 import { determineIsFormFields } from './util/validate'
+import { MissingPublicKeyError } from './errors'
+import {
+  encryptMessage,
+  decryptContent,
+  verifySignedMessage,
+  generateKeypair,
+} from './util/crypto'
 
-/**
- * Encrypt input with a unique keypair for each submission
- * @param encryptionPublicKey The base-64 encoded public key for encrypting.
- * @param msg The message to encrypt, will be stringified.
- * @param signingPrivateKey Optional. Must be a base-64 encoded private key,  will be used to signing the given msg param prior to encrypting.
- * @returns The encrypted basestring.
- */
-function encrypt(
-  msg: any,
-  encryptionPublicKey: string,
-  signingPrivateKey?: string
-): EncryptedContent {
-  let processedMsg = decodeUTF8(JSON.stringify(msg))
-
-  if (signingPrivateKey) {
-    processedMsg = nacl.sign(processedMsg, decodeBase64(signingPrivateKey))
-  }
-
-  return _encrypt(processedMsg, encryptionPublicKey)
-}
-
-/**
- * Helper function to encrypt input with a unique keypair for each submission.
- * @param msg The message to encrypt
- * @param theirPublicKey The base-64 encoded public key
- * @returns The encrypted basestring
- * @throws error if any of the encrypt methods fail
- */
-function _encrypt(msg: Uint8Array, theirPublicKey: string): EncryptedContent {
-  const submissionKeypair = generate()
-  const nonce = nacl.randomBytes(24)
-  const encrypted = encodeBase64(
-    nacl.box(
-      msg,
-      nonce,
-      decodeBase64(theirPublicKey),
-      decodeBase64(submissionKeypair.secretKey)
-    )
-  )
-  return `${submissionKeypair.publicKey};${encodeBase64(nonce)}:${encrypted}`
-}
-
-/**
- * Helper method to decrypt an encrypted submission.
- * @param formPrivateKey base64
- * @param encryptedContent encrypted string encoded in base64
- * @return The decrypted content, or null if decryption failed.
- */
-function _decrypt(
-  formPrivateKey: string,
-  encryptedContent: EncryptedContent
-): Uint8Array | null {
-  try {
-    const [submissionPublicKey, nonceEncrypted] = encryptedContent.split(';')
-    const [nonce, encrypted] = nonceEncrypted.split(':').map(decodeBase64)
-    return nacl.box.open(
-      encrypted,
-      nonce,
-      decodeBase64(submissionPublicKey),
-      decodeBase64(formPrivateKey)
-    )
-  } catch (err) {
-    return null
-  }
-}
-
-/**
- * Helper method to verify a signed message.
- * @param msg the message to verify
- * @param publicKey the public key to authenticate the signed message with
- * @returns the signed message if successful, else an error will be thrown.
- */
-function _verifySignedMessage(
-  msg: Uint8Array,
+export default class Crypto {
   publicKey: string
-): Record<string, any> {
-  const openedMessage = nacl.sign.open(msg, decodeBase64(publicKey))
-  if (!openedMessage)
-    throw new Error('Failed to open signed message with given public key')
-  return JSON.parse(encodeUTF8(openedMessage))
-}
+  constructor({ publicKey }: { publicKey: string }) {
+    this.publicKey = publicKey
+  }
 
-/**
- * Higher order function returning a function to decrypt an encrypted
- * submission.
- * @param signingPublicKey The public key to open verified objects that was signed with the private key passed to this library.
- */
-function decrypt(signingPublicKey: string) {
+  /**
+   * Encrypt input with a unique keypair for each submission
+   * @param encryptionPublicKey The base-64 encoded public key for encrypting.
+   * @param msg The message to encrypt, will be stringified.
+   * @param signingPrivateKey Optional. Must be a base-64 encoded private key. If given, will be used to signing the given msg param prior to encrypting.
+   * @returns The encrypted basestring.
+   */
+  encrypt = (
+    msg: any,
+    encryptionPublicKey: string,
+    signingPrivateKey?: string
+  ): EncryptedContent => {
+    let processedMsg = decodeUTF8(JSON.stringify(msg))
+
+    if (signingPrivateKey) {
+      processedMsg = nacl.sign(processedMsg, decodeBase64(signingPrivateKey))
+    }
+
+    return encryptMessage(processedMsg, encryptionPublicKey)
+  }
+
   /**
    * Decrypts an encrypted submission and returns it.
    * @param formSecretKey The base-64 secret key of the form to decrypt with.
@@ -116,17 +59,18 @@ function decrypt(signingPublicKey: string) {
    * @param decryptParams.version The version of the payload. Used to determine the decryption process to decrypt the content with.
    * @param decryptParams.verifiedContent Optional. The encrypted and signed verified content. If given, the signingPublicKey will be used to attempt to open the signed message.
    * @returns The decrypted content if successful. Else, null will be returned.
+   * @throws {MissingPublicKeyError} if a public key is not provided when instantiating this class and is needed for verifying signed content.
    */
-  function _internalDecrypt(
+  decrypt = (
     formSecretKey: string,
     decryptParams: DecryptParams
-  ): DecryptedContent | null {
+  ): DecryptedContent | null => {
     try {
       const { encryptedContent, verifiedContent, version } = decryptParams
 
       // Do not return the transformed object in `_decrypt` function as a signed
       // object is not encoded in UTF8 and is encoded in Base-64 instead.
-      const decryptedContent = _decrypt(formSecretKey, encryptedContent)
+      const decryptedContent = decryptContent(formSecretKey, encryptedContent)
       if (!decryptedContent) {
         throw new Error('Failed to decrypt content')
       }
@@ -140,10 +84,13 @@ function decrypt(signingPublicKey: string) {
       }
 
       if (verifiedContent) {
+        if (!this.publicKey) {
+          throw new MissingPublicKeyError()
+        }
         // Only care if it is the correct shape if verifiedContent exists, since
         // we need to append it to the end.
         // Decrypted message must be able to be authenticated by the public key.
-        const decryptedVerifiedContent = _decrypt(
+        const decryptedVerifiedContent = decryptContent(
           formSecretKey,
           verifiedContent
         )
@@ -151,9 +98,9 @@ function decrypt(signingPublicKey: string) {
           // Returns null if verification for decrypt failed.
           throw new Error('Verification failed for signature')
         }
-        const decryptedVerifiedObject = _verifySignedMessage(
+        const decryptedVerifiedObject = verifySignedMessage(
           decryptedVerifiedContent,
-          signingPublicKey
+          this.publicKey
         )
 
         returnedObject.verified = decryptedVerifiedObject
@@ -161,108 +108,88 @@ function decrypt(signingPublicKey: string) {
 
       return returnedObject
     } catch (err) {
+      // Should only throw if MissingPublicKeyError.
+      // This library should be able to be used to encrypt and decrypt content
+      // if the content does not contain verified fields.
+      if (err instanceof MissingPublicKeyError) {
+        throw err
+      }
       return null
     }
   }
-  return _internalDecrypt
-}
 
-/**
- * Generates a new keypair for encryption.
- * @returns The generated keypair.
- */
-function generate(): Keypair {
-  const kp = nacl.box.keyPair()
-  return {
-    publicKey: encodeBase64(kp.publicKey),
-    secretKey: encodeBase64(kp.secretKey),
-  }
-}
+  /**
+   * Generates a new keypair for encryption.
+   * @returns The generated keypair.
+   */
+  generate = generateKeypair
 
-function valid(signingPublicKey: string) {
   /**
    * Returns true if a pair of public & secret keys are associated with each other
    * @param publicKey The public key to verify against.
    * @param secretKey The private key to verify against.
    */
-  function _internalValid(publicKey: string, secretKey: string) {
+  valid = (publicKey: string, secretKey: string) => {
     const testResponse: FormField[] = []
     const internalValidationVersion = 1
 
-    try {
-      const cipherResponse = encrypt(testResponse, publicKey)
-      // Use toString here since the return should be an empty array.
-      return (
-        testResponse.toString() ===
-        decrypt(signingPublicKey)(secretKey, {
-          encryptedContent: cipherResponse,
-          version: internalValidationVersion,
-        })?.responses.toString()
-      )
-    } catch (err) {
-      return false
+    const cipherResponse = this.encrypt(testResponse, publicKey)
+    // Use toString here since the return should be an empty array.
+    return (
+      testResponse.toString() ===
+      this.decrypt(secretKey, {
+        encryptedContent: cipherResponse,
+        version: internalValidationVersion,
+      })?.responses.toString()
+    )
+  }
+
+  /**
+   * Encrypt given binary file with a unique keypair for each submission.
+   * @param binary The file to encrypt, should be a blob that is converted to Uint8Array binary
+   * @param formPublicKey The base-64 encoded public key
+   * @returns Promise holding the encrypted file
+   * @throws error if any of the encrypt methods fail
+   */
+  encryptFile = async (
+    binary: Uint8Array,
+    formPublicKey: string
+  ): Promise<EncryptedFileContent> => {
+    const submissionKeypair = this.generate()
+    const nonce = nacl.randomBytes(24)
+    return {
+      submissionPublicKey: submissionKeypair.publicKey,
+      nonce: encodeBase64(nonce),
+      binary: nacl.box(
+        binary,
+        nonce,
+        decodeBase64(formPublicKey),
+        decodeBase64(submissionKeypair.secretKey)
+      ),
     }
   }
-  return _internalValid
-}
 
-/**
- * Helper function to encrypt file with a unique keypair for each submission.
- * @param binary The file to encrypt, should be a blob that is converted to { @type Uint8Array} binary
- * @param formPublicKey The base-64 encoded public key
- * @returns Promise holding the encrypted file
- * @throws error if any of the encrypt methods fail
- */
-async function encryptFile(
-  binary: Uint8Array,
-  formPublicKey: string
-): Promise<EncryptedFileContent> {
-  const submissionKeypair = generate()
-  const nonce = nacl.randomBytes(24)
-  return {
-    submissionPublicKey: submissionKeypair.publicKey,
-    nonce: encodeBase64(nonce),
-    binary: nacl.box(
-      binary,
+  /**
+   * Decrypt the given encrypted file content.
+   * @param formSecretKey Secret key as a base-64 string
+   * @param encrypted Object returned from encryptFile function
+   * @param encrypted.submissionPublicKey The submission public key as a base-64 string
+   * @param encrypted.nonce The nonce as a base-64 string
+   * @param encrypted.blob The encrypted file as a Blob object
+   */
+  decryptFile = async (
+    formSecretKey: string,
+    {
+      submissionPublicKey,
       nonce,
-      decodeBase64(formPublicKey),
-      decodeBase64(submissionKeypair.secretKey)
-    ),
-  }
-}
-
-/**
- * Helper function to decrypt a file
- * @param formSecretKey Secret key as a base-64 string
- * @param encrypted Object returned from encryptFile function
- * @param encrypted.submissionPublicKey The submission public key as a base-64 string
- * @param encrypted.nonce The nonce as a base-64 string
- * @param encrypted.blob The encrypted file as a Blob object
- */
-async function decryptFile(
-  formSecretKey: string,
-  { submissionPublicKey, nonce, binary: encryptedBinary }: EncryptedFileContent
-): Promise<Uint8Array | null> {
-  return nacl.box.open(
-    encryptedBinary,
-    decodeBase64(nonce),
-    decodeBase64(submissionPublicKey),
-    decodeBase64(formSecretKey)
-  )
-}
-
-/**
- * Provider that accepts configuration before returning the crypto module to
- * init.
- */
-export = function ({ mode, publicKey }: PackageInitParams) {
-  const signingPublicKey = publicKey || getPublicKey(mode || 'production')
-  return {
-    encrypt,
-    decrypt: decrypt(signingPublicKey),
-    generate,
-    valid: valid(signingPublicKey),
-    encryptFile,
-    decryptFile,
+      binary: encryptedBinary,
+    }: EncryptedFileContent
+  ): Promise<Uint8Array | null> => {
+    return nacl.box.open(
+      encryptedBinary,
+      decodeBase64(nonce),
+      decodeBase64(submissionPublicKey),
+      decodeBase64(formSecretKey)
+    )
   }
 }

--- a/src/crypto.ts
+++ b/src/crypto.ts
@@ -27,7 +27,7 @@ import {
 export default class Crypto {
   publicSigningKey?: string
 
-  constructor({ publicSigningKey }: { publicSigningKey?: string }) {
+  constructor({ publicSigningKey }: { publicSigningKey?: string } = {}) {
     this.publicSigningKey = publicSigningKey
   }
 

--- a/src/crypto.ts
+++ b/src/crypto.ts
@@ -25,9 +25,10 @@ import {
 } from './util/crypto'
 
 export default class Crypto {
-  publicKey: string
-  constructor({ publicKey }: { publicKey: string }) {
-    this.publicKey = publicKey
+  publicSigningKey?: string
+
+  constructor({ publicSigningKey }: { publicSigningKey?: string }) {
+    this.publicSigningKey = publicSigningKey
   }
 
   /**
@@ -84,8 +85,10 @@ export default class Crypto {
       }
 
       if (verifiedContent) {
-        if (!this.publicKey) {
-          throw new MissingPublicKeyError()
+        if (!this.publicSigningKey) {
+          throw new MissingPublicKeyError(
+            'Public signing key must be provided when instantiating the Crypto class in order to verify verified content'
+          )
         }
         // Only care if it is the correct shape if verifiedContent exists, since
         // we need to append it to the end.
@@ -100,7 +103,7 @@ export default class Crypto {
         }
         const decryptedVerifiedObject = verifySignedMessage(
           decryptedVerifiedContent,
-          this.publicKey
+          this.publicSigningKey
         )
 
         returnedObject.verified = decryptedVerifiedObject

--- a/src/crypto.ts
+++ b/src/crypto.ts
@@ -98,8 +98,8 @@ export default class Crypto {
           verifiedContent
         )
         if (!decryptedVerifiedContent) {
-          // Returns null if verification for decrypt failed.
-          throw new Error('Verification failed for signature')
+          // Returns null if decrypting verified content failed.
+          throw new Error('Failed to decrypt verified content')
         }
         const decryptedVerifiedObject = verifySignedMessage(
           decryptedVerifiedContent,

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -10,6 +10,18 @@ class MissingSecretKeyError extends Error {
     Object.setPrototypeOf(this, MissingSecretKeyError.prototype)
   }
 }
+class MissingPublicKeyError extends Error {
+  constructor(
+    message = 'Provide a public key when when initializing the FormSG SDK to use this function.'
+  ) {
+    super(message)
+    this.name = this.constructor.name
+
+    // Set the prototype explicitly.
+    // See https://github.com/facebook/jest/issues/8279
+    Object.setPrototypeOf(this, MissingPublicKeyError.prototype)
+  }
+}
 
 class WebhookAuthenticateError extends Error {
   constructor(message: string) {
@@ -21,4 +33,8 @@ class WebhookAuthenticateError extends Error {
   }
 }
 
-export { MissingSecretKeyError, WebhookAuthenticateError }
+export {
+  MissingSecretKeyError,
+  MissingPublicKeyError,
+  WebhookAuthenticateError,
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,6 +3,7 @@ import { PackageInitParams } from './types'
 import verification from './verification'
 import Webhooks from './webhooks'
 import { getPublicKey } from './util/publicKey'
+import Crypto from './crypto'
 /**
  * Entrypoint into the FormSG SDK
  * @param {PackageInitParams} config Package initialization config parameters
@@ -12,14 +13,14 @@ import { getPublicKey } from './util/publicKey'
  */
 export = function (config: PackageInitParams = {}) {
   const { publicKey, webhookSecretKey, mode } = config
-  const webhookPublicKey = publicKey || getPublicKey(mode || 'production')
+  const encryptionPublicKey = publicKey || getPublicKey(mode || 'production')
 
   return {
     webhooks: new Webhooks({
-      publicKey: webhookPublicKey,
+      publicKey: encryptionPublicKey,
       secretKey: webhookSecretKey,
     }),
-    crypto: crypto(config),
+    crypto: new Crypto({ publicKey: encryptionPublicKey }),
     verification: verification(config),
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -20,7 +20,7 @@ export = function (config: PackageInitParams = {}) {
       publicKey: encryptionPublicKey,
       secretKey: webhookSecretKey,
     }),
-    crypto: new Crypto({ publicKey: encryptionPublicKey }),
+    crypto: new Crypto({ publicSigningKey: encryptionPublicKey }),
     verification: verification(config),
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,9 +1,11 @@
-import crypto from './crypto'
 import { PackageInitParams } from './types'
+
+import { getPublicKey } from './util/publicKey'
+
 import verification from './verification'
 import Webhooks from './webhooks'
-import { getPublicKey } from './util/publicKey'
 import Crypto from './crypto'
+
 /**
  * Entrypoint into the FormSG SDK
  * @param {PackageInitParams} config Package initialization config parameters

--- a/src/util/crypto.ts
+++ b/src/util/crypto.ts
@@ -1,0 +1,81 @@
+import { encodeBase64, decodeBase64, encodeUTF8 } from 'tweetnacl-util'
+import nacl from 'tweetnacl'
+
+import { Keypair, EncryptedContent } from '../types'
+
+/**
+ * Helper method to generate a new keypair for encryption.
+ * @returns The generated keypair.
+ */
+export const generateKeypair = (): Keypair => {
+  const kp = nacl.box.keyPair()
+  return {
+    publicKey: encodeBase64(kp.publicKey),
+    secretKey: encodeBase64(kp.secretKey),
+  }
+}
+
+/**
+ * Helper function to encrypt input with a unique keypair for each submission.
+ * @param msg The message to encrypt
+ * @param theirPublicKey The base-64 encoded public key
+ * @returns The encrypted basestring
+ * @throws error if any of the encrypt methods fail
+ */
+export const encryptMessage = (
+  msg: Uint8Array,
+  theirPublicKey: string
+): EncryptedContent => {
+  const submissionKeypair = generateKeypair()
+  const nonce = nacl.randomBytes(24)
+  const encrypted = encodeBase64(
+    nacl.box(
+      msg,
+      nonce,
+      decodeBase64(theirPublicKey),
+      decodeBase64(submissionKeypair.secretKey)
+    )
+  )
+  return `${submissionKeypair.publicKey};${encodeBase64(nonce)}:${encrypted}`
+}
+
+/**
+ * Helper method to decrypt an encrypted submission.
+ * @param formPrivateKey base64
+ * @param encryptedContent encrypted string encoded in base64
+ * @return The decrypted content, or null if decryption failed.
+ */
+export const decryptContent = (
+  formPrivateKey: string,
+  encryptedContent: EncryptedContent
+): Uint8Array | null => {
+  try {
+    const [submissionPublicKey, nonceEncrypted] = encryptedContent.split(';')
+    const [nonce, encrypted] = nonceEncrypted.split(':').map(decodeBase64)
+    return nacl.box.open(
+      encrypted,
+      nonce,
+      decodeBase64(submissionPublicKey),
+      decodeBase64(formPrivateKey)
+    )
+  } catch (err) {
+    return null
+  }
+}
+
+/**
+ * Helper method to verify a signed message.
+ * @param msg the message to verify
+ * @param publicKey the public key to authenticate the signed message with
+ * @returns the signed message if successful, else an error will be thrown
+ * @throws {Error} if the message cannot be verified
+ */
+export const verifySignedMessage = (
+  msg: Uint8Array,
+  publicKey: string
+): Record<string, any> => {
+  const openedMessage = nacl.sign.open(msg, decodeBase64(publicKey))
+  if (!openedMessage)
+    throw new Error('Failed to open signed message with given public key')
+  return JSON.parse(encodeUTF8(openedMessage))
+}

--- a/src/webhooks.ts
+++ b/src/webhooks.ts
@@ -25,7 +25,7 @@ export default class Webhooks {
    * @param header X-FormSG-Signature header
    * @param uri The endpoint that FormSG is POSTing to
    * @returns true if the header is verified
-   * @throws {Error} If the signature or uri cannot be verified
+   * @throws {WebhookAuthenticateError} If the signature or uri cannot be verified
    */
   authenticate = (header: string, uri: string) => {
     // Parse the header


### PR DESCRIPTION
Part two of the refactor, meant to keep the PR size manageable.

Related to #31

Note that this PR is pointing to part 1: Webhook HOF -> class refactor

The current chain is:
master -> webhooks -> **crypto (this)**