### PR TITLE
test: add tests for new package initialisation

### DIFF
--- a/spec/init.spec.ts
+++ b/spec/init.spec.ts
@@ -1,7 +1,99 @@
 import formsg from '../src/index'
+import {
+  getVerificationPublicKey,
+  getSigningPublicKey,
+} from '../src/util/publicKey'
+import { VERIFICATION_KEYS } from '../src/resource/verification-keys'
+import { SIGNING_KEYS } from '../src/resource/signing-keys'
+import Webhooks from '../src/webhooks'
+import Crypto from '../src/crypto'
+import Verification from '../src/verification'
+
+const TEST_PUBLIC_KEY = SIGNING_KEYS.test.publicKey
 
 describe('FormSG SDK', () => {
-  it('should be able to initialise without arguments', () => {
-    expect(() => formsg()).not.toThrow()
+  describe('Initialisation', () => {
+    it('should be able to initialise without arguments', () => {
+      expect(() => formsg()).not.toThrow()
+    })
+
+    it('should be able to initialise with valid verification options', () => {
+      // Arrange
+      const TEST_TRANSACTION_EXPIRY = 10000
+      const sdk = formsg({
+        mode: 'test',
+        verificationOptions: {
+          secretKey: VERIFICATION_KEYS.test.secretKey,
+          transactionExpiry: TEST_TRANSACTION_EXPIRY,
+        },
+      })
+
+      expect(sdk.verification.verificationPublicKey).toEqual(
+        VERIFICATION_KEYS.test.publicKey
+      )
+      expect(sdk.verification.verificationSecretKey).toEqual(
+        VERIFICATION_KEYS.test.secretKey
+      )
+      expect(sdk.verification.transactionExpiry).toEqual(
+        TEST_TRANSACTION_EXPIRY
+      )
+    })
+  })
+
+  describe('Public keys', () => {
+    it('should get the correct verification public key given a mode', () => {
+      expect(getVerificationPublicKey('test')).toBe(
+        VERIFICATION_KEYS.test.publicKey
+      )
+      expect(getVerificationPublicKey('staging')).toBe(
+        VERIFICATION_KEYS.staging.publicKey
+      )
+      expect(getVerificationPublicKey('development')).toBe(
+        VERIFICATION_KEYS.development.publicKey
+      )
+      expect(getVerificationPublicKey('production')).toBe(
+        VERIFICATION_KEYS.production.publicKey
+      )
+      expect(getVerificationPublicKey()).toBe(
+        VERIFICATION_KEYS.production.publicKey
+      )
+    })
+  })
+
+  it('should get the correct signing key given a mode', () => {
+    expect(getSigningPublicKey('test')).toBe(SIGNING_KEYS.test.publicKey)
+    expect(getSigningPublicKey('staging')).toBe(SIGNING_KEYS.staging.publicKey)
+    expect(getSigningPublicKey('development')).toBe(
+      SIGNING_KEYS.development.publicKey
+    )
+    expect(getSigningPublicKey('production')).toBe(
+      SIGNING_KEYS.production.publicKey
+    )
+    expect(getSigningPublicKey()).toBe(SIGNING_KEYS.production.publicKey)
+  })
+
+  it('should be able to initialise with given publicKey init param', () => {
+    // Arrange
+    // Expected inner class public keys
+    const expectedWebhookPublicKey = new Webhooks({
+      publicKey: TEST_PUBLIC_KEY,
+    }).publicKey
+    const expectedCryptoPublicKey = new Crypto({
+      publicSigningKey: TEST_PUBLIC_KEY,
+    }).publicSigningKey
+    const expectedVerificationPublicKey = new Verification({
+      verificationPublicKey: TEST_PUBLIC_KEY,
+    }).verificationPublicKey
+
+    // Act
+    // Create SDK with a public key
+    const sdk = formsg({ publicKey: TEST_PUBLIC_KEY })
+
+    // Assert
+    expect(sdk.crypto.publicSigningKey).toEqual(expectedCryptoPublicKey)
+    expect(sdk.verification.verificationPublicKey).toEqual(
+      expectedVerificationPublicKey
+    )
+    expect(sdk.webhooks.publicKey).toEqual(expectedWebhookPublicKey)
   })
 })

--- a/spec/init.spec.ts
+++ b/spec/init.spec.ts
@@ -73,15 +73,15 @@ describe('FormSG SDK', () => {
   })
 
   it('should be able to initialise with given publicKey init param', () => {
-    // Arrange
-
     // Act
-    // Create SDK with a public key
-    const sdk = formsg({ publicKey: TEST_PUBLIC_KEY })
+    const userSpecifiedKey = TEST_PUBLIC_KEY
+    // Create SDK with a specified public key
+    const sdk = formsg({ publicKey: userSpecifiedKey })
 
     // Assert
-    expect(sdk.crypto.publicSigningKey).toEqual(TEST_PUBLIC_KEY)
-    expect(sdk.verification.verificationPublicKey).toEqual(TEST_PUBLIC_KEY)
-    expect(sdk.webhooks.publicKey).toEqual(TEST_PUBLIC_KEY)
+    // All various keys used by subpackages should be the given public key.
+    expect(sdk.crypto.publicSigningKey).toEqual(userSpecifiedKey)
+    expect(sdk.verification.verificationPublicKey).toEqual(userSpecifiedKey)
+    expect(sdk.webhooks.publicKey).toEqual(userSpecifiedKey)
   })
 })

--- a/spec/init.spec.ts
+++ b/spec/init.spec.ts
@@ -74,26 +74,14 @@ describe('FormSG SDK', () => {
 
   it('should be able to initialise with given publicKey init param', () => {
     // Arrange
-    // Expected inner class public keys
-    const expectedWebhookPublicKey = new Webhooks({
-      publicKey: TEST_PUBLIC_KEY,
-    }).publicKey
-    const expectedCryptoPublicKey = new Crypto({
-      publicSigningKey: TEST_PUBLIC_KEY,
-    }).publicSigningKey
-    const expectedVerificationPublicKey = new Verification({
-      verificationPublicKey: TEST_PUBLIC_KEY,
-    }).verificationPublicKey
 
     // Act
     // Create SDK with a public key
     const sdk = formsg({ publicKey: TEST_PUBLIC_KEY })
 
     // Assert
-    expect(sdk.crypto.publicSigningKey).toEqual(expectedCryptoPublicKey)
-    expect(sdk.verification.verificationPublicKey).toEqual(
-      expectedVerificationPublicKey
-    )
-    expect(sdk.webhooks.publicKey).toEqual(expectedWebhookPublicKey)
+    expect(sdk.crypto.publicSigningKey).toEqual(TEST_PUBLIC_KEY)
+    expect(sdk.verification.verificationPublicKey).toEqual(TEST_PUBLIC_KEY)
+    expect(sdk.webhooks.publicKey).toEqual(TEST_PUBLIC_KEY)
   })
 })


### PR DESCRIPTION
The **last**!!!! part of the refactor, meant to keep the PR size manageable.

This PR adds tests for the new package initialisations.

Related to #31

The current chain is:
master -> webhooks -> crypto -> verification -> **this**