### PR TITLE
fix(FormField): account for table responses

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -35,7 +35,7 @@ export type FormField = {
   signature?: string
 } & (
   | { answer: string; answerArray?: never }
-  | { answer?: never; answerArray: string[] }
+  | { answer?: never; answerArray: string[] | string[][] }
 )
 
 // Encrypted basestring containing the submission public key,


### PR DESCRIPTION
Responses containing tabular data take the form `string[][]`, but this is 
not reflected in the appropriate `answerArray`. Change the type declaration
to accommodate.