### PR TITLE
Release 0.8.3 - Allow tolerance for clock drift when authenticating webhooks

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@opengovsg/formsg-sdk",
-  "version": "0.8.2",
+  "version": "0.8.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opengovsg/formsg-sdk",
-  "version": "0.8.2",
+  "version": "0.8.3",
   "repository": {
     "type": "git",
     "url": "https://github.com/opengovsg/formsg-javascript-sdk.git"

--- a/spec/webhooks.spec.ts
+++ b/spec/webhooks.spec.ts
@@ -54,11 +54,65 @@ describe('Webhooks', () => {
       signature,
     }) as string
 
-    webhook.authenticate(header, uri)
+    expect(() => webhook.authenticate(header, uri)).not.toThrow()
   })
 
   it('should reject signatures generated more than 5 minutes ago', () => {
-    const epoch = Date.now() - 5 * 60 * 1000 - 1
+    const epoch = Date.now() - 5 * 60 * 1000 - 1 // 5min 1s into the past
+    const signature = webhook.generateSignature({
+      uri,
+      submissionId,
+      formId,
+      epoch,
+    }) as string
+    const header = webhook.constructHeader({
+      epoch,
+      submissionId,
+      formId,
+      signature,
+    }) as string
+
+    expect(() => webhook.authenticate(header, uri)).toThrow()
+  })
+
+  it('should accept signatures generated within 5 minutes', () => {
+    const epoch = Date.now() - 5 * 60 * 1000 + 1000 // 4min 59s into the past
+    const signature = webhook.generateSignature({
+      uri,
+      submissionId,
+      formId,
+      epoch,
+    }) as string
+    const header = webhook.constructHeader({
+      epoch,
+      submissionId,
+      formId,
+      signature,
+    }) as string
+
+    expect(() => webhook.authenticate(header, uri)).not.toThrow()
+  })
+
+  it('should authenticate signatures if Form server drifts 4m59s into the future', () => {
+    const epoch = Date.now() + 5 * 60 * 1000 - 1000 // 4min 59s into the future
+    const signature = webhook.generateSignature({
+      uri,
+      submissionId,
+      formId,
+      epoch,
+    }) as string
+    const header = webhook.constructHeader({
+      epoch,
+      submissionId,
+      formId,
+      signature,
+    }) as string
+
+    expect(() => webhook.authenticate(header, uri)).not.toThrow()
+  })
+
+  it('should reject signatures if Form server drifts 5m1s into the future', () => {
+    const epoch = Date.now() + 5 * 60 * 1000 + 1000 // 5min 1s into the future
     const signature = webhook.generateSignature({
       uri,
       submissionId,

--- a/src/webhooks.ts
+++ b/src/webhooks.ts
@@ -29,13 +29,14 @@ function verifySignature(
 
 /**
  * Helper function to verify that the epoch submitted is recent.
- * Prevents against replay attacks.
- * @param epoch The number of milliseconds since Jan 1, 1979
+ * Prevents against replay attacks. Allows for negative time interval
+ * in case of clock drift between Form servers and recipient server.
+ * @param epoch The number of milliseconds since 1 Jan 1970 00:00:00 UTC
  * @param expiry Duration of expiry. The default is 5 minutes.
  */
 function verifyEpoch(epoch: number, expiry: number = 300000) {
-  const difference = Date.now() - epoch
-  return difference > 0 && difference < expiry
+  const difference = Math.abs(Date.now() - epoch)
+  return difference < expiry
 }
 
 /**


### PR DESCRIPTION
# Problem

The epoch timestamp check necessary to prevent replay attacks during webhook authentication does not provide any tolerance for clock drift. Authentication fails if Form servers drift into the future sufficiently, or if the recipient server drifts into the past.  This is because the time interval at authentication needed to be within (0, 5) minutes.

# Solution

Accommodate timestamp drift on either Form server or recipient server, as long as the time interval is within (-5, 5) minutes.