### PR TITLE
ref: use mode init parameter again

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,15 +19,13 @@ npm install @opengovsg/formsg-sdk --save
 
 ```javascript
 const formsg = require('@opengovsg/formsg-sdk')({
-  publicKey: 'replace-me-with-public-key',
+  mode: 'production',
 })
 ```
 
-| Option    | Description                                                                                           |
-| --------- |  ---------------------------------------------------------------------------------------------------- |
-| publicKey | (required) This public key is used to authenticate or verify signed objects passed into this package. |
-
-You can find the public key for the FormSG staging and production environments at the bottom of this README.md file.
+| Option | Default      | Description                                                     |
+| ------ | ------------ | --------------------------------------------------------------- |
+| mode   | 'production' | Set to 'staging' if integrating against FormSG staging servers. |
 
 ## Usage
 

--- a/spec/crypto.spec.ts
+++ b/spec/crypto.spec.ts
@@ -17,7 +17,7 @@ const signingSecretKey = SIGNING_KEYS.test.secretKey
 const testFileBuffer = new Uint8Array(Buffer.from('./resources/ogp.svg'))
 
 describe('Crypto', function () {
-  const crypto = new Crypto({ publicSigningKey: encryptionPublicKey })
+  const crypto = new Crypto({ signingPublicKey: encryptionPublicKey })
 
   const mockVerifiedContent = {
     uinFin: 'S12345679Z',

--- a/spec/init.spec.ts
+++ b/spec/init.spec.ts
@@ -1,20 +1,32 @@
 import formsg from '../src/index'
-import {
-  getVerificationPublicKey,
-  getSigningPublicKey,
-} from '../src/util/publicKey'
-import { VERIFICATION_KEYS } from '../src/resource/verification-keys'
 import { SIGNING_KEYS } from '../src/resource/signing-keys'
-import Webhooks from '../src/webhooks'
-import Crypto from '../src/crypto'
-import Verification from '../src/verification'
-
-const TEST_PUBLIC_KEY = SIGNING_KEYS.test.publicKey
+import { VERIFICATION_KEYS } from '../src/resource/verification-keys'
+import {
+  getSigningPublicKey,
+  getVerificationPublicKey,
+} from '../src/util/publicKey'
 
 describe('FormSG SDK', () => {
   describe('Initialisation', () => {
     it('should be able to initialise without arguments', () => {
-      expect(() => formsg()).not.toThrow()
+      const sdk = formsg()
+      // Should be autopopulated with production public keys.
+      expect(sdk.crypto.signingPublicKey).toEqual(
+        SIGNING_KEYS.production.publicKey
+      )
+      expect(sdk.verification.verificationPublicKey).toEqual(
+        VERIFICATION_KEYS.production.publicKey
+      )
+      expect(sdk.webhooks.publicKey).toEqual(SIGNING_KEYS.production.publicKey)
+    })
+
+    it('should correctly assign given webhook signing key', async () => {
+      const mockSecretKey = 'mock secret key'
+      const sdk = formsg({
+        webhookSecretKey: mockSecretKey,
+      })
+
+      expect(sdk.webhooks.secretKey).toEqual(mockSecretKey)
     })
 
     it('should be able to initialise with valid verification options', () => {
@@ -58,30 +70,19 @@ describe('FormSG SDK', () => {
         VERIFICATION_KEYS.production.publicKey
       )
     })
-  })
 
-  it('should get the correct signing key given a mode', () => {
-    expect(getSigningPublicKey('test')).toBe(SIGNING_KEYS.test.publicKey)
-    expect(getSigningPublicKey('staging')).toBe(SIGNING_KEYS.staging.publicKey)
-    expect(getSigningPublicKey('development')).toBe(
-      SIGNING_KEYS.development.publicKey
-    )
-    expect(getSigningPublicKey('production')).toBe(
-      SIGNING_KEYS.production.publicKey
-    )
-    expect(getSigningPublicKey()).toBe(SIGNING_KEYS.production.publicKey)
-  })
-
-  it('should be able to initialise with given publicKey init param', () => {
-    // Act
-    const userSpecifiedKey = TEST_PUBLIC_KEY
-    // Create SDK with a specified public key
-    const sdk = formsg({ publicKey: userSpecifiedKey })
-
-    // Assert
-    // All various keys used by subpackages should be the given public key.
-    expect(sdk.crypto.publicSigningKey).toEqual(userSpecifiedKey)
-    expect(sdk.verification.verificationPublicKey).toEqual(userSpecifiedKey)
-    expect(sdk.webhooks.publicKey).toEqual(userSpecifiedKey)
+    it('should get the correct signing key given a mode', () => {
+      expect(getSigningPublicKey('test')).toBe(SIGNING_KEYS.test.publicKey)
+      expect(getSigningPublicKey('staging')).toBe(
+        SIGNING_KEYS.staging.publicKey
+      )
+      expect(getSigningPublicKey('development')).toBe(
+        SIGNING_KEYS.development.publicKey
+      )
+      expect(getSigningPublicKey('production')).toBe(
+        SIGNING_KEYS.production.publicKey
+      )
+      expect(getSigningPublicKey()).toBe(SIGNING_KEYS.production.publicKey)
+    })
   })
 })

--- a/spec/verification/verification.spec.ts
+++ b/spec/verification/verification.spec.ts
@@ -2,8 +2,8 @@ import { VERIFICATION_KEYS } from '../../src/resource/verification-keys'
 import Verification from '../../src/verification'
 import { MissingSecretKeyError, MissingPublicKeyError } from '../../src/errors'
 
-const publicKey = VERIFICATION_KEYS.test.publicKey
-const secretKey = VERIFICATION_KEYS.test.secretKey
+const TEST_PUBLIC_KEY = VERIFICATION_KEYS.test.publicKey
+const TEST_SECRET_KEY = VERIFICATION_KEYS.test.secretKey
 
 const TEST_TRANSACTION_EXPIRY = 10000
 const TEST_PARAMS = {
@@ -43,7 +43,7 @@ describe('Verification', () => {
       const verification = new Verification({
         // No public key provided.
         transactionExpiry: TEST_TRANSACTION_EXPIRY,
-        verificationSecretKey: secretKey,
+        secretKey: TEST_SECRET_KEY,
       })
 
       expect(() => verification.authenticate(VALID_AUTH_PAYLOAD)).toThrow(
@@ -54,8 +54,8 @@ describe('Verification', () => {
     it('should not authenticate if transaction expiry is not provided', () => {
       const verification = new Verification({
         // No transaction expiry provided.
-        verificationPublicKey: publicKey,
-        verificationSecretKey: secretKey,
+        publicKey: TEST_PUBLIC_KEY,
+        secretKey: TEST_SECRET_KEY,
       })
 
       expect(() => verification.authenticate(VALID_AUTH_PAYLOAD)).toThrow(
@@ -67,8 +67,8 @@ describe('Verification', () => {
   describe('Usage', () => {
     const verification = new Verification({
       transactionExpiry: TEST_TRANSACTION_EXPIRY,
-      verificationSecretKey: secretKey,
-      verificationPublicKey: publicKey,
+      secretKey: TEST_SECRET_KEY,
+      publicKey: TEST_PUBLIC_KEY,
     })
 
     let now: jest.MockInstance<number, any>

--- a/src/crypto.ts
+++ b/src/crypto.ts
@@ -25,10 +25,10 @@ import {
 } from './util/crypto'
 
 export default class Crypto {
-  publicSigningKey?: string
+  signingPublicKey?: string
 
-  constructor({ publicSigningKey }: { publicSigningKey?: string } = {}) {
-    this.publicSigningKey = publicSigningKey
+  constructor({ signingPublicKey }: { signingPublicKey?: string } = {}) {
+    this.signingPublicKey = signingPublicKey
   }
 
   /**
@@ -85,7 +85,7 @@ export default class Crypto {
       }
 
       if (verifiedContent) {
-        if (!this.publicSigningKey) {
+        if (!this.signingPublicKey) {
           throw new MissingPublicKeyError(
             'Public signing key must be provided when instantiating the Crypto class in order to verify verified content'
           )
@@ -103,7 +103,7 @@ export default class Crypto {
         }
         const decryptedVerifiedObject = verifySignedMessage(
           decryptedVerifiedContent,
-          this.publicSigningKey
+          this.signingPublicKey
         )
 
         returnedObject.verified = decryptedVerifiedObject

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,7 +14,7 @@ import Crypto from './crypto'
  * @param {string?} [config.webhookSecretKey] Optional. base64 secret key for signing webhooks. If provided, enables generating signature and headers to authenticate webhook data.
  * @param {VerificationOptions?} [config.verificationOptions] Optional. If provided, enables the usage of the verification module.
  */
-export default function (config: PackageInitParams = {}) {
+export = function (config: PackageInitParams = {}) {
   const { webhookSecretKey, mode, verificationOptions } = config
   const signingPublicKey = getSigningPublicKey(mode || 'production')
   const verificationPublicKey = getVerificationPublicKey(mode || 'production')

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,44 +7,24 @@ import Webhooks from './webhooks'
 import Crypto from './crypto'
 
 /**
- * Deprecated entrypoint into the FormSG SDK
- * Deprecated since January 2021.
+ * Entrypoint into the FormSG SDK
  *
  * @param {PackageInitParams} config Package initialization config parameters
  * @param {string?} [config.mode] Optional. Initializes public key used for verifying and decrypting in this package. If `config.signingPublicKey` is given, this param will be ignored.
  * @param {string?} [config.webhookSecretKey] Optional. base64 secret key for signing webhooks. If provided, enables generating signature and headers to authenticate webhook data.
  * @param {VerificationOptions?} [config.verificationOptions] Optional. If provided, enables the usage of the verification module.
  */
-
-/**
- * Entrypoint into the FormSG SDK
- *
- * @param {PackageInitParams} config Package initialization config parameters
- * @param {string} [config.signingPublicKey] This public key is used to either encrypt objects or verify webhook objects passed into this package.
- * @param {string?} [config.webhookSecretKey] Optional. base64 secret key for signing webhooks. If provided, enables generating signature and headers to authenticate webhook data.
- * @param {VerificationOptions?} [config.verificationOptions] Optional. If provided, enables the usage of the verification module.
- */
 export default function (config: PackageInitParams = {}) {
   const { webhookSecretKey, mode, verificationOptions } = config
-  // Backwards compatible way to also allow for `mode` parameter until it is fully removed.
-  const publicSigningKey =
-    config.signingPublicKey || getSigningPublicKey(mode || 'production')
-  const verificationPublicKey =
-    config.verificationOptions?.publicKey ||
-    getVerificationPublicKey(mode || 'production')
-
-  if (typeof mode !== 'undefined') {
-    console.warn(
-      'Initializing the FormSG SDK with the `mode` parameter is now deprecated. Please switch to the publicKey parameter instead.'
-    )
-  }
+  const signingPublicKey = getSigningPublicKey(mode || 'production')
+  const verificationPublicKey = getVerificationPublicKey(mode || 'production')
 
   return {
     webhooks: new Webhooks({
-      publicKey: publicSigningKey,
+      publicKey: signingPublicKey,
       secretKey: webhookSecretKey,
     }),
-    crypto: new Crypto({ publicSigningKey }),
+    crypto: new Crypto({ signingPublicKey }),
     verification: new Verification({
       publicKey: verificationPublicKey,
       secretKey: verificationOptions?.secretKey,

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,7 +16,14 @@ import Crypto from './crypto'
  */
 export = function (config: PackageInitParams = {}) {
   const { webhookSecretKey, mode, verificationOptions } = config
+  /**
+   * Public key is used for decrypting signed verified content in the `crypto` module, and
+   * also for verifying webhook signatures' authenticity in the `wehbooks` module.
+   */
   const signingPublicKey = getSigningPublicKey(mode || 'production')
+  /**
+   * Public key is used for verifying verified field signatures' authenticity in the `verification` module.
+   */
   const verificationPublicKey = getVerificationPublicKey(mode || 'production')
 
   return {

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,40 +7,48 @@ import Webhooks from './webhooks'
 import Crypto from './crypto'
 
 /**
- * Entrypoint into the FormSG SDK
- * @param {PackageInitParams} config Package initialization config parameters
- * @param {string} [config.publicKey] This public key is used to authenticate or verify signed objects passed into this package.
- * @param {string?} [config.webhookSecretKey] Optional base64 secret key for signing webhooks
- *//**
  * Deprecated entrypoint into the FormSG SDK
  *
  * @deprecated since January 2021
  * @param {PackageInitParams} config Package initialization config parameters
- * @param {string?} [config.publicKey] Optional. If provided, this public key will be used instead to authenticate or verify signed objects passed into this package.
  * @param {string?} [config.mode] Optional. Initializes public key used for verifying and decrypting in this package. If `config.signingPublicKey` is given, this param will be ignored.
- * @param {string?} [config.webhookSecretKey] Optional base64 secret key for signing webhooks
+ * @param {string?} [config.webhookSecretKey] Optional. base64 secret key for signing webhooks. If provided, enables generating signature and headers to authenticate webhook data.
+ * @param {VerificationOptions?} [config.verificationOptions] Optional. If provided, enables the usage of the verification module.
  */
-export = function (config: PackageInitParams = {}) {
-  const { publicKey, webhookSecretKey, mode, verificationOptions } = config
-  const encryptionPublicKey =
-    publicKey || getSigningPublicKey(mode || 'production')
+
+/**
+ * Entrypoint into the FormSG SDK
+ *
+ * @param {PackageInitParams} config Package initialization config parameters
+ * @param {string} [config.signingPublicKey] This public key is used to either encrypt objects or verify webhook objects passed into this package.
+ * @param {string?} [config.webhookSecretKey] Optional. base64 secret key for signing webhooks. If provided, enables generating signature and headers to authenticate webhook data.
+ * @param {VerificationOptions?} [config.verificationOptions] Optional. If provided, enables the usage of the verification module.
+ */
+export default function (config: PackageInitParams = {}) {
+  const { webhookSecretKey, mode, verificationOptions } = config
+  // Backwards compatible way to also allow for `mode` parameter until it is fully removed.
+  const publicSigningKey =
+    config.signingPublicKey || getSigningPublicKey(mode || 'production')
   const verificationPublicKey =
-    publicKey || getVerificationPublicKey(mode || 'production')
+    config.verificationOptions?.publicKey ||
+    getVerificationPublicKey(mode || 'production')
 
   if (typeof mode !== 'undefined') {
-    console.warn('Initializing the FormSG SDK with the `mode` parameter is now deprecated. Please switch to the publicKey parameter instead.')
+    console.warn(
+      'Initializing the FormSG SDK with the `mode` parameter is now deprecated. Please switch to the publicKey parameter instead.'
+    )
   }
 
   return {
     webhooks: new Webhooks({
-      publicKey: encryptionPublicKey,
+      publicKey: publicSigningKey,
       secretKey: webhookSecretKey,
     }),
-    crypto: new Crypto({ publicSigningKey: encryptionPublicKey }),
+    crypto: new Crypto({ publicSigningKey }),
     verification: new Verification({
-      verificationPublicKey,
+      publicKey: verificationPublicKey,
+      secretKey: verificationOptions?.secretKey,
       transactionExpiry: verificationOptions?.transactionExpiry,
-      verificationSecretKey: verificationOptions?.secretKey,
     }),
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,8 +8,8 @@ import Crypto from './crypto'
 
 /**
  * Deprecated entrypoint into the FormSG SDK
+ * Deprecated since January 2021.
  *
- * @deprecated since January 2021
  * @param {PackageInitParams} config Package initialization config parameters
  * @param {string?} [config.mode] Optional. Initializes public key used for verifying and decrypting in this package. If `config.signingPublicKey` is given, this param will be ignored.
  * @param {string?} [config.webhookSecretKey] Optional. base64 secret key for signing webhooks. If provided, enables generating signature and headers to authenticate webhook data.

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,18 +1,11 @@
 export type PackageInitParams = {
+  /** base64 secret key for signing webhooks. If provided, enables generating signature and headers to authenticate webhook data. */
   webhookSecretKey?: string
+  /** If provided, enables the usage of the verification module. */
   verificationOptions?: VerificationOptions
-} & (
-  | {
-      signingPublicKey?: string
-      /** @deprecated Please switch to using the `signingPublicKey` and `verificationOptions.publicKey` parameters instead. Deprecated since January 2021. */
-      mode?: never
-    }
-  | {
-      signingPublicKey?: never
-      /** @deprecated Please switch to using the `signingPublicKey` and `verificationOptions.publicKey` parameters instead. Deprecated since January 2021. */
-      mode?: PackageMode
-    }
-)
+  /** Initializes public key used for verifying and decrypting in this package. If not given, will default to "production". */
+  mode?: PackageMode
+}
 
 // A field type available in FormSG as a string
 export type FieldType =

--- a/src/types.ts
+++ b/src/types.ts
@@ -2,8 +2,16 @@ export type PackageInitParams = {
   webhookSecretKey?: string
   verificationOptions?: VerificationOptions
 } & (
-  | { publicKey?: string; mode?: never }
-  | { publicKey?: never; mode?: PackageMode }
+  | {
+      signingPublicKey?: string
+      /** @deprecated Please switch to using the `signingPublicKey` and `verificationOptions.publicKey` parameters instead. Deprecated since January 2021. */
+      mode?: never
+    }
+  | {
+      signingPublicKey?: never
+      /** @deprecated Please switch to using the `signingPublicKey` and `verificationOptions.publicKey` parameters instead. Deprecated since January 2021. */
+      mode?: PackageMode
+    }
 )
 
 // A field type available in FormSG as a string
@@ -70,6 +78,7 @@ export type Keypair = {
 export type PackageMode = 'staging' | 'production' | 'development' | 'test'
 
 export type VerificationOptions = {
+  publicKey?: string
   secretKey?: string
   transactionExpiry?: number
 }

--- a/src/verification/index.ts
+++ b/src/verification/index.ts
@@ -8,6 +8,7 @@ import { decodeUTF8, decodeBase64, encodeBase64 } from 'tweetnacl-util'
 import {
   VerificationSignatureOptions,
   VerificationAuthenticateOptions,
+  VerificationOptions,
 } from '../types'
 
 import { MissingSecretKeyError, MissingPublicKeyError } from '../errors'
@@ -20,18 +21,10 @@ export default class Verification {
   verificationSecretKey?: string
   transactionExpiry?: number
 
-  constructor({
-    verificationPublicKey,
-    verificationSecretKey,
-    transactionExpiry,
-  }: {
-    verificationPublicKey?: string
-    verificationSecretKey?: string
-    transactionExpiry?: number
-  }) {
-    this.verificationPublicKey = verificationPublicKey
-    this.verificationSecretKey = verificationSecretKey
-    this.transactionExpiry = transactionExpiry
+  constructor(params?: VerificationOptions) {
+    this.verificationPublicKey = params?.publicKey
+    this.verificationSecretKey = params?.secretKey
+    this.transactionExpiry = params?.transactionExpiry
   }
 
   /**


### PR DESCRIPTION
This PR builds on #34, #36, #38 but removed the `publicKey` parameter after extensive discussion with @liangyuanruo 

## Reasons for removal
1. Allowing users to update their public keys as an environment variable wouldn't have worked seamlessly anyways in the event of a private key leak, and would require users to be disseminated new public keys and to use the new public keys.

Would be easier to actually update the sdk and make users update??
