### PR TITLE
fix: update .npmignore to ignore misc unneeded files

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,1 +1,8 @@
 src
+coverage
+spec
+.prettierrc.js
+.travis.yml
+jest.config.js
+tsconfig.json
+package-lock.json


### PR DESCRIPTION
## Info
Our publish npm package was including lots of unneeded files that were increasing the size of the sdk.

Before to after size difference:
```
packed size: 44.4 kB -> 16.3 kB
```
```
unpacked size: 155.6 kB -> 63.0 kB
```

## Solution
- update `.npmignore` to ignore misc unneeded files

## Before
```
npm notice
npm notice 📦  @opengovsg/formsg-sdk@0.8.3
npm notice === Tarball Contents ===
npm notice 5.4kB  coverage/lcov-report/base.css
npm notice 676B   coverage/lcov-report/prettify.css
npm notice 17.7kB coverage/lcov-report/spec/resources/crypto-data-20200322.ts.html
npm notice 5.3kB  coverage/lcov-report/spec/resources/crypto-data-20200604.ts.html
npm notice 3.5kB  coverage/lcov-report/index.html
npm notice 5.0kB  coverage/lcov-report/spec/resources/index.html
npm notice 0      coverage/lcov.info
npm notice 81B    .prettierrc.js
npm notice 3.0kB  dist/verification/authenticate.js
npm notice 396B   dist/verification/basestring.js
npm notice 2.4kB  coverage/lcov-report/block-navigation.js
npm notice 11.8kB dist/crypto.js
npm notice 2.8kB  dist/util/crypto.js
npm notice 2.6kB  dist/errors.js
npm notice 1.1kB  dist/verification/generate-signature.js
npm notice 931B   dist/verification/get-public-key.js
npm notice 939B   dist/index.js
npm notice 1.4kB  dist/verification/index.js
npm notice 325B   jest.config.js
npm notice 863B   dist/util/parser.js
npm notice 17.6kB coverage/lcov-report/prettify.js
npm notice 890B   dist/util/publicKey.js
npm notice 1.4kB  dist/util/signature.js
npm notice 723B   dist/resource/signing-keys.js
npm notice 5.3kB  coverage/lcov-report/sorter.js
npm notice 223B   dist/util/stage.js
npm notice 77B    dist/types.js
npm notice 807B   dist/verification/utils.js
npm notice 814B   dist/util/validate.js
npm notice 728B   dist/resource/verification-keys.js
npm notice 2.1kB  dist/util/webhooks.js
npm notice 5.1kB  dist/webhooks.js
npm notice 3B     coverage/coverage-final.json
npm notice 983B   package.json
npm notice 363B   tsconfig.json
npm notice 9.4kB  README.md
npm notice 540B   coverage/lcov-report/favicon.png
npm notice 209B   coverage/lcov-report/sort-arrow-sprite.png
npm notice 9.1kB  spec/resources/ogp.svg
npm notice 89B    dist/verification/authenticate.d.ts
npm notice 260B   dist/verification/basestring.d.ts
npm notice 4.3kB  spec/resources/crypto-data-20200322.ts
npm notice 633B   spec/resources/crypto-data-20200604.ts
npm notice 2.2kB  dist/crypto.d.ts
npm notice 1.3kB  dist/util/crypto.d.ts
npm notice 6.1kB  spec/crypto.spec.ts
npm notice 353B   dist/errors.d.ts
npm notice 190B   dist/verification/generate-signature.d.ts
npm notice 268B   dist/verification/get-public-key.d.ts
npm notice 1.9kB  dist/index.d.ts
npm notice 541B   dist/verification/index.d.ts
npm notice 178B   spec/init.spec.ts
npm notice 619B   dist/util/parser.d.ts
npm notice 264B   dist/util/publicKey.d.ts
npm notice 685B   dist/util/signature.d.ts
npm notice 267B   dist/resource/signing-keys.d.ts
npm notice 123B   dist/util/stage.d.ts
npm notice 1.8kB  dist/types.d.ts
npm notice 548B   dist/verification/utils.d.ts
npm notice 142B   dist/util/validate.d.ts
npm notice 272B   dist/resource/verification-keys.d.ts
npm notice 3.8kB  spec/verification.spec.ts
npm notice 1.1kB  dist/util/webhooks.d.ts
npm notice 1.1kB  dist/webhooks.d.ts
npm notice 3.5kB  spec/webhooks.spec.ts
npm notice 396B   coverage/clover.xml
npm notice 241B   .travis.yml
npm notice === Tarball Details ===
npm notice name:          @opengovsg/formsg-sdk
npm notice version:       0.8.3
npm notice package size:  44.4 kB
npm notice unpacked size: 155.6 kB
npm notice shasum:        a82f9929d53184d32489b49fd5cb3e8c413e7f70
npm notice integrity:     sha512-2pqO1UpXsYvBN[...]GcNN6Ti3IMBrA==
npm notice total files:   67
npm notice
+ @opengovsg/formsg-sdk@0.8.3
```

## After
```
npm notice
npm notice 📦  @opengovsg/formsg-sdk@0.8.3
npm notice === Tarball Contents ===
npm notice 3.0kB  dist/verification/authenticate.js
npm notice 396B   dist/verification/basestring.js
npm notice 11.8kB dist/crypto.js
npm notice 2.8kB  dist/util/crypto.js
npm notice 2.6kB  dist/errors.js
npm notice 1.1kB  dist/verification/generate-signature.js
npm notice 931B   dist/verification/get-public-key.js
npm notice 939B   dist/index.js
npm notice 1.4kB  dist/verification/index.js
npm notice 863B   dist/util/parser.js
npm notice 890B   dist/util/publicKey.js
npm notice 1.4kB  dist/util/signature.js
npm notice 723B   dist/resource/signing-keys.js
npm notice 223B   dist/util/stage.js
npm notice 77B    dist/types.js
npm notice 807B   dist/verification/utils.js
npm notice 814B   dist/util/validate.js
npm notice 728B   dist/resource/verification-keys.js
npm notice 2.1kB  dist/util/webhooks.js
npm notice 5.1kB  dist/webhooks.js
npm notice 983B   package.json
npm notice 9.4kB  README.md
npm notice 89B    dist/verification/authenticate.d.ts
npm notice 260B   dist/verification/basestring.d.ts
npm notice 2.2kB  dist/crypto.d.ts
npm notice 1.3kB  dist/util/crypto.d.ts
npm notice 353B   dist/errors.d.ts
npm notice 190B   dist/verification/generate-signature.d.ts
npm notice 268B   dist/verification/get-public-key.d.ts
npm notice 1.9kB  dist/index.d.ts
npm notice 541B   dist/verification/index.d.ts
npm notice 619B   dist/util/parser.d.ts
npm notice 264B   dist/util/publicKey.d.ts
npm notice 685B   dist/util/signature.d.ts
npm notice 267B   dist/resource/signing-keys.d.ts
npm notice 123B   dist/util/stage.d.ts
npm notice 1.8kB  dist/types.d.ts
npm notice 548B   dist/verification/utils.d.ts
npm notice 142B   dist/util/validate.d.ts
npm notice 272B   dist/resource/verification-keys.d.ts
npm notice 1.1kB  dist/util/webhooks.d.ts
npm notice 1.1kB  dist/webhooks.d.ts
npm notice === Tarball Details ===
npm notice name:          @opengovsg/formsg-sdk
npm notice version:       0.8.3
npm notice package size:  16.3 kB
npm notice unpacked size: 63.0 kB
npm notice shasum:        8a16b58abddc4d13289679ce8fb5611b85251c23
npm notice integrity:     sha512-VA854g5KVkma7[...]7NOMim6cEEsqw==
npm notice total files:   42
npm notice
+ @opengovsg/formsg-sdk@0.8.3
```