### PR TITLE
build: release v0.8.4-beta.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@opengovsg/formsg-sdk",
-  "version": "0.8.3",
+  "version": "0.8.4-beta.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opengovsg/formsg-sdk",
-  "version": "0.8.3",
+  "version": "0.8.4-beta.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/opengovsg/formsg-javascript-sdk.git"


### PR DESCRIPTION
Released this under the `beta` tag and version number `0.8.4-beta.0` for testing purposes.