### PR TITLE
add downloadAndDecryptAttachments for downloading and decrypting attachments

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,49 @@ app.post(
   }
 )
 
+// Example for submissions with attachments
+app.post(
+  '/submissions-attachment',
+  // Endpoint authentication by verifying signatures
+  function (req, res, next) {
+    try {
+      formsg.webhooks.authenticate(req.get('X-FormSG-Signature'), POST_URI)
+      // Continue processing the POST body
+      return next()
+    } catch (e) {
+      return res.status(401).send({ message: 'Unauthorized' })
+    }
+  },
+  // Parse JSON from raw request body
+  express.json(),
+  // Decrypt the submission and attachments
+  async function (req, res, next) {
+    // `req.body.data` is an object fulfilling the DecryptParams interface.
+    // interface DecryptParams {
+    //   encryptedContent: EncryptedContent
+    //   version: number
+    //   verifiedContent?: EncryptedContent
+    // }
+    /** @type {{content: DecryptedContent, attachments: DecryptedAttachments}} */
+    const submission = formsg.crypto.decryptWithAttachments(
+      formSecretKey,
+      // If `verifiedContent` is provided in `req.body.data`, the return object
+      // will include a verified key.
+      req.body.data
+    )
+
+    // If the decryption failed, submission will be `null`.
+    if (submission) {
+      // Continue processing the submission
+
+      // processSubmission(submission.content)
+      // processAttachments(submission.attachments)
+    } else {
+      // Could not decrypt the submission
+    }
+  }
+)
+
 app.listen(8080, () => console.log('Running on port 8080'))
 ```
 

--- a/README.md
+++ b/README.md
@@ -103,6 +103,7 @@ The underlying cryptosystem is `x25519-xsalsa20-poly1305` which is implemented b
 | submissionId     | string | Unique response identifier, displayed as 'Response ID' to form respondents       |
 | encryptedContent | string | The encrypted submission in base64. |
 | created          | string | Creation timestamp.                 |
+| attachmentDownloadUrls | Record<string, string> | (Optional) Records containing field IDs and URLs where encrypted uploaded attachments can be downloaded. |
 
 ### Format of Decrypted Submissions
 

--- a/README.md
+++ b/README.md
@@ -159,6 +159,22 @@ If the decrypted content is the correct shape, then:
    verified content. **If the verification fails, `null` is returned, even if
    `decryptParams.encryptedContent` was successfully decrypted.**
 
+### Processing Attachments
+
+`formsg.crypto.decryptWithAttachments(formSecretKey: string, decryptParams: DecryptParams) behaves similarly except it will return a `Promise<DecryptedContentAndAttachments | null>`.
+
+`DecryptedContentAndAttachments` is an object containing two fields: 
+ - `content`: the standard form decrypted responses (same as the return type of `formsg.crypto.decrypt`)
+ - `attachments`: A `Record<string, DecryptedFile>` containing a map of field ids of the attachment fields to a object containing the original user supplied filename and a `Uint8Array` containing the contents of the uploaded file.
+
+If the contents of any file fails to decrypt or there is a mismatch between the attachments and submission (e.g. the submission doesn't contain the original file name), then `null` will be returned.
+
+Attachments are downloaded using S3 pre-signed URLs, with a expiry time of *one hour*. You must call `decryptWithAttachments` within this time window, or else the URL to the encrypted files will become invalid.
+
+Attachments are end-to-end encrypted in the same way as normal form submissions, so any eavesdropper will not be able to view form attachments without your secret key.
+
+*Warning:* We do not have the ability to scan any attachments for malicious content (e.g. spyware or viruses), so careful handling is neeeded.
+
 ## Verifying Signatures Manually
 
 You can use the following information to create a custom solution, although we recommend using this SDK.

--- a/README.md
+++ b/README.md
@@ -161,7 +161,7 @@ If the decrypted content is the correct shape, then:
 
 ### Processing Attachments
 
-`formsg.crypto.decryptWithAttachments(formSecretKey: string, decryptParams: DecryptParams) behaves similarly except it will return a `Promise<DecryptedContentAndAttachments | null>`.
+`formsg.crypto.decryptWithAttachments(formSecretKey: string, decryptParams: DecryptParams)` behaves similarly except it will return a `Promise<DecryptedContentAndAttachments | null>`.
 
 `DecryptedContentAndAttachments` is an object containing two fields: 
  - `content`: the standard form decrypted responses (same as the return type of `formsg.crypto.decrypt`)

--- a/README.md
+++ b/README.md
@@ -63,13 +63,6 @@ app.post(
   express.json(),
   // Decrypt the submission
   function (req, res, next) {
-    // `req.body.data` is an object fulfilling the DecryptParams interface.
-    // interface DecryptParams {
-    //   encryptedContent: EncryptedContent
-    //   version: number
-    //   verifiedContent?: EncryptedContent
-    // }
-    /** @type {{responses: FormField[], verified?: Record<string, any>}} */
     const submission = formsg.crypto.decrypt(
       formSecretKey,
       // If `verifiedContent` is provided in `req.body.data`, the return object
@@ -103,14 +96,6 @@ app.post(
   express.json(),
   // Decrypt the submission and attachments
   async function (req, res, next) {
-    // `req.body.data` is an object fulfilling the DecryptParams interface.
-    // interface DecryptParams {
-    //   encryptedContent: EncryptedContent
-    //   version: number
-    //   verifiedContent?: EncryptedContent
-    //   attachmentDownloadUrls?: Record<string, string>
-    // }
-    /** @type {{content: DecryptedContent, attachments: DecryptedAttachments}} */
     const submission = formsg.crypto.decryptWithAttachments(
       formSecretKey,
       // If `verifiedContent` is provided in `req.body.data`, the return object

--- a/README.md
+++ b/README.md
@@ -108,6 +108,7 @@ app.post(
     //   encryptedContent: EncryptedContent
     //   version: number
     //   verifiedContent?: EncryptedContent
+    //   attachmentDownloadUrls?: Record<string, string>
     // }
     /** @type {{content: DecryptedContent, attachments: DecryptedAttachments}} */
     const submission = formsg.crypto.decryptWithAttachments(
@@ -117,7 +118,7 @@ app.post(
       req.body.data
     )
 
-    // If the decryption failed, submission will be `null`.
+    // If the decryption failed at any point, submission will be `null`.
     if (submission) {
       // Continue processing the submission
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1436,6 +1436,11 @@
         "type-detect": "4.0.8"
       }
     },
+    "@stablelib/base64": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@stablelib/base64/-/base64-1.0.0.tgz",
+      "integrity": "sha512-s/wTc/3+vYSalh4gfayJrupzhT7SDBqNtiYOeEMlkSDqL/8cExh5FAeTzLpmYq+7BLLv36EjBL5xrb0bUHWJWQ=="
+    },
     "@types/babel__core": {
       "version": "7.1.7",
       "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.1.7.tgz",
@@ -1758,6 +1763,14 @@
       "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.9.1.tgz",
       "integrity": "sha512-wMHVg2EOHaMRxbzgFJ9gtjOOCrI80OHLG14rxi28XwOW8ux6IiEbRCGGGqCtdAIg4FQCbW20k9RsT4y3gJlFug==",
       "dev": true
+    },
+    "axios": {
+      "version": "0.21.1",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.1.tgz",
+      "integrity": "sha512-dKQiRHxGD9PPRIUNIWvZhPTPpl1rf/OxTYKsqKUDjBwYylTvV7SjSHJb9ratfyzM6wCdLCOYLzs73qpg5c4iGA==",
+      "requires": {
+        "follow-redirects": "^1.10.0"
+      }
     },
     "babel-jest": {
       "version": "25.3.0",
@@ -2764,6 +2777,11 @@
       "requires": {
         "locate-path": "^3.0.0"
       }
+    },
+    "follow-redirects": {
+      "version": "1.14.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.0.tgz",
+      "integrity": "sha512-0vRwd7RKQBTt+mgu87mtYeofLFZpTas2S9zY+jIeuLJMNvudIgF52nr19q40HOwH5RrhWIPuj9puybzSJiRrVg=="
     },
     "for-in": {
       "version": "1.0.2",
@@ -4380,6 +4398,15 @@
       "dev": true,
       "requires": {
         "@jest/types": "^25.3.0"
+      }
+    },
+    "jest-mock-axios": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/jest-mock-axios/-/jest-mock-axios-4.4.0.tgz",
+      "integrity": "sha512-MF5MbjIZcv2KCtO6oH/Fmy1sML1LxQoaGyIPRGArDdd9pcsfjWoCmFFUD12GgOTeJw8ChjuVYHN0s8QnhGriQA==",
+      "dev": true,
+      "requires": {
+        "synchronous-promise": "^2.0.15"
       }
     },
     "jest-pnp-resolver": {
@@ -6109,6 +6136,12 @@
       "version": "3.2.4",
       "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
       "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "dev": true
+    },
+    "synchronous-promise": {
+      "version": "2.0.15",
+      "resolved": "https://registry.npmjs.org/synchronous-promise/-/synchronous-promise-2.0.15.tgz",
+      "integrity": "sha512-k8uzYIkIVwmT+TcglpdN50pS2y1BDcUnBPK9iJeGu0Pl1lOI8pD6wtzgw91Pjpe+RxtTncw32tLxs/R0yNL2Mg==",
       "dev": true
     },
     "terminal-link": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1436,11 +1436,6 @@
         "type-detect": "4.0.8"
       }
     },
-    "@stablelib/base64": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@stablelib/base64/-/base64-1.0.0.tgz",
-      "integrity": "sha512-s/wTc/3+vYSalh4gfayJrupzhT7SDBqNtiYOeEMlkSDqL/8cExh5FAeTzLpmYq+7BLLv36EjBL5xrb0bUHWJWQ=="
-    },
     "@types/babel__core": {
       "version": "7.1.7",
       "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.1.7.tgz",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,6 @@
   "author": "Open Government Products (FormSG)",
   "license": "MIT",
   "dependencies": {
-    "@stablelib/base64": "^1.0.0",
     "axios": "^0.21.1",
     "tweetnacl": "^1.0.3",
     "tweetnacl-util": "^0.15.1"

--- a/package.json
+++ b/package.json
@@ -23,6 +23,8 @@
   "author": "Open Government Products (FormSG)",
   "license": "MIT",
   "dependencies": {
+    "@stablelib/base64": "^1.0.0",
+    "axios": "^0.21.1",
     "tweetnacl": "^1.0.3",
     "tweetnacl-util": "^0.15.1"
   },
@@ -34,6 +36,7 @@
     "@types/node": "^13.11.1",
     "coveralls": "^3.1.0",
     "jest": "^25.3.0",
+    "jest-mock-axios": "^4.4.0",
     "ts-jest": "^25.3.1",
     "typescript": "^3.8.3"
   }

--- a/spec/crypto.spec.ts
+++ b/spec/crypto.spec.ts
@@ -369,7 +369,6 @@ describe('Crypto', function () {
       attachmentDownloadUrls: { '6e771c946b3c5100240368e5': 'https://some.s3.url/some/encrypted/file' },
       version: INTERNAL_TEST_VERSION,
     })
-    mockAxios.mockResponse({ data: { encryptedFile: uploadedFile }})
     const decryptedContents = await decryptedFilesPromise
 
     // Assert

--- a/src/crypto.ts
+++ b/src/crypto.ts
@@ -208,7 +208,10 @@ export default class Crypto {
    * @returns The decrypted attachments if successful. Else, null will be returned.
    * @throws {MissingPublicKeyError} if a public key is not provided when instantiating this class and is needed for verifying signed content.
    */
-  downloadAndDecryptAttachments = async(formSecretKey: string, decryptParams: DecryptParams): Promise<DecryptedAttachments | null> => {
+  downloadAndDecryptAttachments = async (
+    formSecretKey: string,
+    decryptParams: DecryptParams
+  ): Promise<DecryptedAttachments | null> => {
     let decryptedRecords: DecryptedAttachments = {}
 
     const attachmentRecords: EncryptedAttachmentRecords = decryptParams.attachmentDownloadUrls ?? {}

--- a/src/crypto.ts
+++ b/src/crypto.ts
@@ -234,8 +234,6 @@ export default class Crypto {
       downloadPromises.push(
         axios.get(attachmentRecords[fieldId], { responseType: 'json' })
       .then((downloadResponse) => {
-        if (downloadResponse.status !== 200) throw new Error("Download failed")
-
         const encryptedAttachment: EncryptedAttachmentContent = downloadResponse.data
         const encryptedFile: EncryptedFileContent = {
           submissionPublicKey: encryptedAttachment.encryptedFile.submissionPublicKey,

--- a/src/types.ts
+++ b/src/types.ts
@@ -45,16 +45,29 @@ export type FormField = {
 // <SubmissionPublicKey>;<Base64Nonce>:<Base64EncryptedData>
 export type EncryptedContent = string
 
+// Records containing a map of field IDs to URLs where encrypted
+// attachments can be downloaded.
+export type EncryptedAttachmentRecords = Record<string, string>
+
 export interface DecryptParams {
   encryptedContent: EncryptedContent
   version: number
   verifiedContent?: EncryptedContent
+  attachmentDownloadUrls?: EncryptedAttachmentRecords
 }
 
 export type DecryptedContent = {
   responses: FormField[]
   verified?: Record<string, any>
 }
+
+export type DecryptedFile = {
+  filename: string
+  content: Uint8Array | null
+}
+
+// Records containing a map of field IDs to DecryptedFiles.
+export type DecryptedAttachments = Record<string, DecryptedFile>
 
 export type EncryptedFileContent = {
   submissionPublicKey: string

--- a/src/types.ts
+++ b/src/types.ts
@@ -63,16 +63,29 @@ export type DecryptedContent = {
 
 export type DecryptedFile = {
   filename: string
-  content: Uint8Array | null
+  content: Uint8Array
 }
 
 // Records containing a map of field IDs to DecryptedFiles.
 export type DecryptedAttachments = Record<string, DecryptedFile>
 
+export type DecryptedContentAndAttachments = {
+  content: DecryptedContent
+  attachments: DecryptedAttachments
+}
+
 export type EncryptedFileContent = {
   submissionPublicKey: string
   nonce: string
   binary: Uint8Array
+}
+
+export type EncryptedAttachmentContent = {
+  encryptedFile: {
+    submissionPublicKey: string
+    nonce: string
+    binary: string
+  }
 }
 
 // A base-64 encoded cryptographic keypair suitable for curve25519.


### PR DESCRIPTION
Adding support for downloading and decrypting attachments sent via webhooks.

Corresponding client-side PR to https://github.com/opengovsg/FormSG/pull/1713

Closes #60