### PR TITLE
docs: specify version for attachment functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,7 +169,7 @@ Attachments are downloaded using S3 pre-signed URLs, with a expiry time of _one 
 
 Attachments are end-to-end encrypted in the same way as normal form submissions, so any eavesdropper will not be able to view form attachments without your secret key.
 
-_Warning:_ We do not have the ability to scan any attachments for malicious content (e.g. spyware or viruses), so careful handling is neeeded.
+_Warning:_ We do not have the ability to scan any attachments for malicious content (e.g. spyware or viruses), so careful handling is needed.
 
 ## Verifying Signatures Manually
 

--- a/README.md
+++ b/README.md
@@ -92,12 +92,12 @@ The underlying cryptosystem is `x25519-xsalsa20-poly1305` which is implemented b
 
 ### Format of Submission Response
 
-| Key              | Type   | Description                         |
-| ---------------- | ------ | ----------------------------------- |
-| formId           | string | Unique form identifier.             |
-| submissionId     | string | Unique response identifier, displayed as 'Response ID' to form respondents       |
-| encryptedContent | string | The encrypted submission in base64. |
-| created          | string | Creation timestamp.                 |
+| Key                    | Type                   | Description                                                                                              |
+| ---------------------- | ---------------------- | -------------------------------------------------------------------------------------------------------- |
+| formId                 | string                 | Unique form identifier.                                                                                  |
+| submissionId           | string                 | Unique response identifier, displayed as 'Response ID' to form respondents                               |
+| encryptedContent       | string                 | The encrypted submission in base64.                                                                      |
+| created                | string                 | Creation timestamp.                                                                                      |
 | attachmentDownloadUrls | Record<string, string> | (Optional) Records containing field IDs and URLs where encrypted uploaded attachments can be downloaded. |
 
 ### Format of Decrypted Submissions
@@ -158,17 +158,18 @@ If the decrypted content is the correct shape, then:
 
 `formsg.crypto.decryptWithAttachments(formSecretKey: string, decryptParams: DecryptParams)` (available from version 0.9.0 onwards) behaves similarly except it will return a `Promise<DecryptedContentAndAttachments | null>`.
 
-`DecryptedContentAndAttachments` is an object containing two fields: 
- - `content`: the standard form decrypted responses (same as the return type of `formsg.crypto.decrypt`)
- - `attachments`: A `Record<string, DecryptedFile>` containing a map of field ids of the attachment fields to a object containing the original user supplied filename and a `Uint8Array` containing the contents of the uploaded file.
+`DecryptedContentAndAttachments` is an object containing two fields:
+
+- `content`: the standard form decrypted responses (same as the return type of `formsg.crypto.decrypt`)
+- `attachments`: A `Record<string, DecryptedFile>` containing a map of field ids of the attachment fields to a object containing the original user supplied filename and a `Uint8Array` containing the contents of the uploaded file.
 
 If the contents of any file fails to decrypt or there is a mismatch between the attachments and submission (e.g. the submission doesn't contain the original file name), then `null` will be returned.
 
-Attachments are downloaded using S3 pre-signed URLs, with a expiry time of *one hour*. You must call `decryptWithAttachments` within this time window, or else the URL to the encrypted files will become invalid.
+Attachments are downloaded using S3 pre-signed URLs, with a expiry time of _one hour_. You must call `decryptWithAttachments` within this time window, or else the URL to the encrypted files will become invalid.
 
 Attachments are end-to-end encrypted in the same way as normal form submissions, so any eavesdropper will not be able to view form attachments without your secret key.
 
-*Warning:* We do not have the ability to scan any attachments for malicious content (e.g. spyware or viruses), so careful handling is neeeded.
+_Warning:_ We do not have the ability to scan any attachments for malicious content (e.g. spyware or viruses), so careful handling is neeeded.
 
 ## Verifying Signatures Manually
 

--- a/README.md
+++ b/README.md
@@ -96,7 +96,8 @@ app.post(
   express.json(),
   // Decrypt the submission and attachments
   async function (req, res, next) {
-    const submission = formsg.crypto.decryptWithAttachments(
+    // Note that this function is only available from version 0.9.0 onwards
+    const submission = await formsg.crypto.decryptWithAttachments(
       formSecretKey,
       // If `verifiedContent` is provided in `req.body.data`, the return object
       // will include a verified key.
@@ -190,7 +191,7 @@ If the decrypted content is the correct shape, then:
 
 ### Processing Attachments
 
-`formsg.crypto.decryptWithAttachments(formSecretKey: string, decryptParams: DecryptParams)` behaves similarly except it will return a `Promise<DecryptedContentAndAttachments | null>`.
+`formsg.crypto.decryptWithAttachments(formSecretKey: string, decryptParams: DecryptParams)` (available from version 0.9.0 onwards) behaves similarly except it will return a `Promise<DecryptedContentAndAttachments | null>`.
 
 `DecryptedContentAndAttachments` is an object containing two fields: 
  - `content`: the standard form decrypted responses (same as the return type of `formsg.crypto.decrypt`)


### PR DESCRIPTION
Adds notes to the README to clarify that `decryptWithAttachments` is only available from v0.9.0 onwards, and also adds a missing `await` to the example code.