### PR TITLE
build: add separate keypairs for dev environment

### DIFF
--- a/spec/keys.spec.ts
+++ b/spec/keys.spec.ts
@@ -1,0 +1,58 @@
+import { SIGNING_KEYS } from '../src/resource/signing-keys'
+import { VERIFICATION_KEYS } from '../src/resource/verification-keys'
+
+describe('Key lengths', () => {
+  // ED25519 key lengths in base64
+  const PUBLIC_KEY_LENGTH = 44
+  const SECRET_KEY_LENGTH = 88
+
+  describe('Verification keys', () => {
+    describe('Public keys', () => {
+      it('should have the correct length for ED25519 public keys', () => {
+        expect(VERIFICATION_KEYS.development.publicKey).toHaveLength(
+          PUBLIC_KEY_LENGTH
+        )
+        expect(VERIFICATION_KEYS.test.publicKey).toHaveLength(PUBLIC_KEY_LENGTH)
+        expect(VERIFICATION_KEYS.staging.publicKey).toHaveLength(
+          PUBLIC_KEY_LENGTH
+        )
+        expect(VERIFICATION_KEYS.production.publicKey).toHaveLength(
+          PUBLIC_KEY_LENGTH
+        )
+      })
+    })
+
+    describe('Secret keys', () => {
+      it('should have the correct length for ED25519 secret keys in test and dev mode', () => {
+        expect(VERIFICATION_KEYS.development.secretKey).toHaveLength(
+          SECRET_KEY_LENGTH
+        )
+        expect(VERIFICATION_KEYS.test.secretKey).toHaveLength(SECRET_KEY_LENGTH)
+      })
+    })
+  })
+
+  describe('Signing keys', () => {
+    describe('Public keys', () => {
+      it('should have the correct length for ED25519 public keys', () => {
+        expect(SIGNING_KEYS.development.publicKey).toHaveLength(
+          PUBLIC_KEY_LENGTH
+        )
+        expect(SIGNING_KEYS.test.publicKey).toHaveLength(PUBLIC_KEY_LENGTH)
+        expect(SIGNING_KEYS.staging.publicKey).toHaveLength(PUBLIC_KEY_LENGTH)
+        expect(SIGNING_KEYS.production.publicKey).toHaveLength(
+          PUBLIC_KEY_LENGTH
+        )
+      })
+    })
+
+    describe('Secret keys', () => {
+      it('should have the correct length for ED25519 secret keys in test and dev mode', () => {
+        expect(SIGNING_KEYS.development.secretKey).toHaveLength(
+          SECRET_KEY_LENGTH
+        )
+        expect(SIGNING_KEYS.test.secretKey).toHaveLength(SECRET_KEY_LENGTH)
+      })
+    })
+  })
+})

--- a/src/resource/signing-keys.ts
+++ b/src/resource/signing-keys.ts
@@ -4,8 +4,8 @@ export const SIGNING_KEYS = {
     publicKey: 'rjv41kYqZwcbe3r6ymMEEKQ+Vd+DPuogN+Gzq3lP2Og=',
   },
   development: {
-    publicKey: '5AYDhjpaloNn4kg7PY0LVpsYAEG/7oI8n1XZjR42vz0=',
-    secretKey: '0oUKRb8q2l8/n32WeXWQ0yiBhEQXTD7i3UPGj2Y0a0g=',
+    publicKey: 'Tl5gfszlKcQj99/0uafLwVpT6JAu4C0dHGvLq1cHzFE=',
+    secretKey: 'HDBXpu+2/gu10bLHpy8HjpN89xbA6boH9GwibPGJA8BOXmB+zOUpxCP33/S5p8vBWlPokC7gLR0ca8urVwfMUQ==',
   },
   production: {
     // production must never contain secret keys

--- a/src/resource/signing-keys.ts
+++ b/src/resource/signing-keys.ts
@@ -4,8 +4,8 @@ export const SIGNING_KEYS = {
     publicKey: 'rjv41kYqZwcbe3r6ymMEEKQ+Vd+DPuogN+Gzq3lP2Og=',
   },
   development: {
-    // Using the same keys for staging.
-    publicKey: 'rjv41kYqZwcbe3r6ymMEEKQ+Vd+DPuogN+Gzq3lP2Og=',
+    publicKey: '5AYDhjpaloNn4kg7PY0LVpsYAEG/7oI8n1XZjR42vz0=',
+    secretKey: '0oUKRb8q2l8/n32WeXWQ0yiBhEQXTD7i3UPGj2Y0a0g=',
   },
   production: {
     // production must never contain secret keys

--- a/src/resource/signing-keys.ts
+++ b/src/resource/signing-keys.ts
@@ -1,3 +1,4 @@
+// keys generated using nacl.sign.keyPair()
 export const SIGNING_KEYS = {
   staging: {
     // staging must never contain secret keys

--- a/src/resource/signing-keys.ts
+++ b/src/resource/signing-keys.ts
@@ -1,4 +1,4 @@
-// keys generated using nacl.sign.keyPair()
+// keys generated using nacl.sign.keyPair() from tweetnacl
 export const SIGNING_KEYS = {
   staging: {
     // staging must never contain secret keys

--- a/src/resource/verification-keys.ts
+++ b/src/resource/verification-keys.ts
@@ -4,8 +4,8 @@ export const VERIFICATION_KEYS = {
     publicKey: 'bDgK1223JbrDNePFIrj7b0z02Z5nSiBzkRYRqDdVPfA=',
   },
   development: {
-    // Using the same keys for staging.
-    publicKey: 'bDgK1223JbrDNePFIrj7b0z02Z5nSiBzkRYRqDdVPfA=',
+    publicKey: 'yMfJ8unVMWfHPoDRY23SdFnWudMXmB6pGfDgBVhRbzs=',
+    secretKey: 'p4iJR5B/YobjRYcIO8iiJmmsMH7YjIr4O1P4DY1lyO0=',
   },
   production: {
     // production must never contain secret keys

--- a/src/resource/verification-keys.ts
+++ b/src/resource/verification-keys.ts
@@ -1,4 +1,4 @@
-// keys generated using nacl.sign.keyPair()
+// keys generated using nacl.sign.keyPair() from tweetnacl
 export const VERIFICATION_KEYS = {
   staging: {
     // staging must never contain secret keys

--- a/src/resource/verification-keys.ts
+++ b/src/resource/verification-keys.ts
@@ -1,3 +1,4 @@
+// keys generated using nacl.sign.keyPair()
 export const VERIFICATION_KEYS = {
   staging: {
     // staging must never contain secret keys

--- a/src/resource/verification-keys.ts
+++ b/src/resource/verification-keys.ts
@@ -4,8 +4,8 @@ export const VERIFICATION_KEYS = {
     publicKey: 'bDgK1223JbrDNePFIrj7b0z02Z5nSiBzkRYRqDdVPfA=',
   },
   development: {
-    publicKey: 'yMfJ8unVMWfHPoDRY23SdFnWudMXmB6pGfDgBVhRbzs=',
-    secretKey: 'p4iJR5B/YobjRYcIO8iiJmmsMH7YjIr4O1P4DY1lyO0=',
+    publicKey: 'SZ4pV0JXgj8dhFU69uHllqYcxTtliYmi+d6Ml56lnQU=',
+    secretKey: 'iGkfOuI6uxrlfw+7CZFFUZBwk86I+pu6v+g7EWA6qJpJnilXQleCPx2EVTr24eWWphzFO2WJiaL53oyXnqWdBQ==',
   },
   production: {
     // production must never contain secret keys

--- a/src/util/publicKey.ts
+++ b/src/util/publicKey.ts
@@ -12,6 +12,7 @@ import STAGE from './stage'
 function getSigningPublicKey(mode?: PackageMode) {
   switch (mode) {
     case STAGE.development:
+      return SIGNING_KEYS.development.publicKey
     case STAGE.staging:
       return SIGNING_KEYS.staging.publicKey
     case STAGE.test:
@@ -29,6 +30,7 @@ function getSigningPublicKey(mode?: PackageMode) {
 function getVerificationPublicKey(mode?: PackageMode) {
   switch (mode) {
     case STAGE.development:
+      return VERIFICATION_KEYS.development.publicKey
     case STAGE.staging:
       return VERIFICATION_KEYS.staging.publicKey
     case STAGE.test:


### PR DESCRIPTION
The dev environment currently uses the same key pairs as staging. This makes it difficult for developers to onboard onto this and the main FormSG repos, as they need access to the staging private keys in order to do dev work.

This PR adds separate signing and verification key pairs for the development environment. These can be used as defaults in the main FormSG repo.

Closes #68 