### PR TITLE
fix: allow empty field titles in decrypted responses

### DIFF
--- a/spec/crypto.spec.ts
+++ b/spec/crypto.spec.ts
@@ -14,6 +14,7 @@ import {
 } from './resources/crypto-data-20200322'
 import { plaintextMultiLang } from './resources/crypto-data-20200604'
 import { MissingPublicKeyError } from '../src/errors'
+import { plaintextEmptyTitles } from './resources/crypto-data-20221114'
 
 const INTERNAL_TEST_VERSION = 1
 
@@ -120,6 +121,21 @@ describe('Crypto', function () {
     })
     // Assert
     expect(decrypted).toHaveProperty('responses', plaintextMultiLang)
+  })
+
+  it('should be able to encrypt and decrypt submissions with empty field titles from 2022-11-14 end-to-end successfully', () => {
+    // Arrange
+    const { publicKey, secretKey } = crypto.generate()
+
+    // Act
+    const ciphertext = crypto.encrypt(plaintextEmptyTitles, publicKey)
+    const decrypted = crypto.decrypt(secretKey, {
+      encryptedContent: ciphertext,
+      version: INTERNAL_TEST_VERSION,
+    })
+    
+    // Assert
+    expect(decrypted).toHaveProperty('responses', plaintextEmptyTitles)
   })
 
   it('should be able to encrypt submissions without signing if signingPrivateKey is missing', () => {

--- a/spec/resources/crypto-data-20221114.ts
+++ b/spec/resources/crypto-data-20221114.ts
@@ -1,0 +1,18 @@
+const plaintextEmptyTitles = [
+  {
+    _id: '5e771c8a6b3c5100240368e1',
+    question: '',
+    fieldType: 'checkbox',
+    answerArray: ['Option 1'],
+  },
+  {
+    _id: '5e771c8a6b3c5100240368e2',
+    question: '',
+    fieldType: 'textfield',
+    answer: 'Test',
+  },
+]
+
+export {
+  plaintextEmptyTitles,
+}

--- a/src/util/validate.ts
+++ b/src/util/validate.ts
@@ -16,7 +16,9 @@ function determineIsFormFields(tbd: any): tbd is FormField[] {
         internal.isHeader) &&
       internal._id &&
       internal.fieldType &&
-      internal.question
+      // The field is still valid even when the question title is empty string
+      // (even though it is not intended behavior).
+      typeof internal.question === 'string'
   )
 
   return filter.length === tbd.length


### PR DESCRIPTION
## Problem

On 14 Nov 2022, a bug was identified in FormSG that allowed admins to create fields with empty field titles via the UI. As an unintended consequence, form responses to such storage mode forms became undecryptable. However, this was not caught to be an issue at the time, and thus was not communicated to form admins. This issue only came to light on 14 Dec 2022, when an admin of an affected form ended up not being able to decrypt form responses.

## Solution

This PR changes the decrypted response validator to check for the type of the field title, in order to allow for empty strings. It also adds a test for this in the spec. 