### PR TITLE
chore(readme): add wording for period inclusion of unstable fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,7 +146,8 @@ decrypted content does not contain all of the fields displayed in the schema bel
 | fieldType   | string   | The type of field for the question.                                                                      |
 | \_id        | string   | A unique identifier of the form field. WARNING: Changes when new fields are created/removed in the form. |
 
-Additional internal fields may be included from time to time, which will then be published above once it is stable for public consumption.
+**Important Note: **
+Additional internal fields may be included in webhooks from time to time, which will then be published as part of our official schema once it is stable for public consumption. If you are applying your own validation, you should account for this e.g. by not rejecting the webhook if there are additional fields included.
 
 The full schema can be viewed in
 [`validate.ts`](https://github.com/opengovsg/formsg-javascript-sdk/tree/master/src/util/validate.ts).

--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ of the returned object.
 Note that due to end-to-end encryption, FormSG servers are unable to verify the data format.
 
 However, the `decrypt` function exposed by this library [validates](https://github.com/opengovsg/formsg-javascript-sdk/blob/master/src/util/validate.ts) the decrypted content and will **return `null` if the
-decrypted content does not fit the schema displayed below.**
+decrypted content does not contain all of the fields displayed in the schema below.**
 
 | Key         | Type     | Description                                                                                              |
 | ----------- | -------- | -------------------------------------------------------------------------------------------------------- |
@@ -145,6 +145,8 @@ decrypted content does not fit the schema displayed below.**
 | answerArray | string[] | The submitter's answer to the question on form. Either this key or `answer` must exist.                  |
 | fieldType   | string   | The type of field for the question.                                                                      |
 | \_id        | string   | A unique identifier of the form field. WARNING: Changes when new fields are created/removed in the form. |
+
+Additional internal fields may be included from time to time, which will then be published above once it is stable for public consumption.
 
 The full schema can be viewed in
 [`validate.ts`](https://github.com/opengovsg/formsg-javascript-sdk/tree/master/src/util/validate.ts).


### PR DESCRIPTION
## Problem

_What problem are you trying to solve? What issue does this close?_

Users might assume that our webhooks will only have the 5 listed fields. This is untrue as we may periodically add internal fields that may be removed. 

Fields that are officially published will not be changed without notice.

## Solution

Update wording to clearly reflect the above.