### PR TITLE
chore: update ci.yml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@ on:
 jobs:
   build:
     name: build
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
       - name: Use Node.js
@@ -27,7 +27,7 @@ jobs:
       - run: npm run build
   test:
     name: test
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
       - name: Use Node.js

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
       - name: Use Node.js
         uses: actions/setup-node@v1
         with:
-          node-version: '10.x'
+          node-version: 18
       - name: Cache Node.js modules
         uses: actions/cache@v2
         with:
@@ -33,7 +33,7 @@ jobs:
       - name: Use Node.js
         uses: actions/setup-node@v1
         with:
-          node-version: '10.x'
+          node-version: 18
       - name: Cache Node.js modules
         uses: actions/cache@v2
         with:


### PR DESCRIPTION
## Problem

No runners are picking up our github actions. We are currently targeting `ubuntu-18.04` which is no longer supported.

## Solution

Using the [latest supported runners](https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners/about-github-hosted-runners#supported-runners-and-hardware-resources)

We also need to upgrade node-version to 18 as the ubuntu-22.x is incompatible with node `10.x`
