### PR TITLE
feat: mrf crypto

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,6 +45,8 @@ jobs:
             ${{ runner.OS }}-
       - run: npm ci
       - run: npm run test-ci
+        env:
+          NODE_OPTIONS: '--max-old-space-size=8192'
       - name: Submit test coverage to Coveralls
         uses: coverallsapp/github-action@v1.1.2
         with:

--- a/jest.config.js
+++ b/jest.config.js
@@ -8,6 +8,6 @@ module.exports = {
     global: {
       statements: 85,
       functions: 80,
-    }
-  }
+    },
+  },
 }

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "scripts": {
-    "test": "jest",
+    "test": "NODE_OPTIONS=\"--max-old-space-size=8192\" jest",
     "test-ci": "jest --coverage",
     "test-watch": "jest --watch",
     "build": "tsc",

--- a/spec/crypto-v3.spec.ts
+++ b/spec/crypto-v3.spec.ts
@@ -100,7 +100,7 @@ describe('CryptoV3', function () {
     // Act
     // Encrypt
     const encrypted = await crypto.encryptFile(testFileBuffer, publicKey)
-    expect(encrypted).toHaveProperty('filePublicKey')
+    expect(encrypted).toHaveProperty('submissionPublicKey')
     expect(encrypted).toHaveProperty('nonce')
     expect(encrypted).toHaveProperty('binary')
 

--- a/spec/crypto-v3.spec.ts
+++ b/spec/crypto-v3.spec.ts
@@ -1,0 +1,406 @@
+import mockAxios from 'jest-mock-axios'
+import { SIGNING_KEYS } from '../src/resource/signing-keys'
+
+import {
+  encodeBase64,
+} from 'tweetnacl-util'
+
+import {
+  plaintext,
+  ciphertext,
+  formPublicKey,
+  formSecretKey,
+  submissionSecretKey
+} from './resources/crypto-v3-data-20231207'
+import { MissingPublicKeyError } from '../src/errors'
+import CryptoV3 from '../src/crypto-v3'
+
+const INTERNAL_TEST_VERSION = 3
+
+const encryptionPublicKey = SIGNING_KEYS.test.publicKey
+const signingSecretKey = SIGNING_KEYS.test.secretKey
+const testFileBuffer = new Uint8Array(Buffer.from('./resources/ogp.svg'))
+
+jest.mock('axios', () => mockAxios)
+
+describe('CryptoV3', function () {
+  afterEach(() => mockAxios.reset())
+
+  const crypto = new CryptoV3()
+
+  const mockVerifiedContent = {
+    uinFin: 'S12345679Z',
+    somethingElse: 99,
+  }
+
+  it('should generate a keypair', () => {
+    const keypair = crypto.generate()
+    expect(keypair).toHaveProperty('secretKey')
+    expect(keypair).toHaveProperty('publicKey')
+  })
+
+  it('should generate a keypair that is valid', () => {
+    const { publicKey, secretKey } = crypto.generate()
+    expect(crypto.valid(publicKey, secretKey)).toBe(true)
+  })
+
+  it('should validate an existing keypair', () => {
+    expect(crypto.valid(formPublicKey, formSecretKey)).toBe(true)
+  })
+
+  it('should invalidate unassociated keypairs', () => {
+    // Act
+    const { secretKey } = crypto.generate()
+    const { publicKey } = crypto.generate()
+
+    // Assert
+    expect(crypto.valid(publicKey, secretKey)).toBe(false)
+  })
+
+  // it('should decrypt the submission ciphertext from 2020-03-22 successfully', () => {
+  //   // Act
+  //   const decrypted = crypto.decrypt(formSecretKey, {
+  //     encryptedContent: ciphertext,
+  //     version: INTERNAL_TEST_VERSION,
+  //   })
+
+  //   // Assert
+  //   expect(decrypted).toHaveProperty('responses', plaintext)
+  // })
+
+  // it('should return null on unsuccessful decryption', () => {
+  //   expect(
+  //     crypto.decrypt('random', {
+  //       encryptedContent: ciphertext,
+  //       version: INTERNAL_TEST_VERSION,
+  //     })
+  //   ).toBe(null)
+  // })
+
+  // it('should return null when successfully decrypted content does not fit FormField type shape', () => {
+  //   // Arrange
+  //   const { publicKey, secretKey } = crypto.generate()
+  //   const malformedContent = 'just a string, not an object with FormField shape'
+  //   const malformedEncrypt = crypto.encrypt(malformedContent, publicKey)
+
+  //   // Assert
+  //   // Using correct secret key, but the decrypted object should not fit the
+  //   // expected shape and thus return null.
+  //   expect(
+  //     crypto.decrypt(secretKey, {
+  //       encryptedContent: malformedEncrypt,
+  //       version: INTERNAL_TEST_VERSION,
+  //     })
+  //   ).toBe(null)
+  // })
+
+  it('should be able to encrypt and decrypt submissions from 2023-12-07 end-to-end successfully from the form private key', () => {
+    // Arrange
+    const { publicKey, secretKey } = crypto.generate()
+
+    // Act
+    const ciphertext = crypto.encrypt(plaintext, publicKey)
+    const decrypted = crypto.decrypt(secretKey, {
+      ...ciphertext,
+      version: INTERNAL_TEST_VERSION,
+    })
+    // Assert
+    expect(decrypted).toHaveProperty('responses', plaintext)
+  })
+
+  it('should be able to decrypt submissions from 2023-12-07 from the submission private key', () => {
+    // Act
+    const decrypted = crypto.decryptFromSubmissionKey(submissionSecretKey, {
+      encryptedContent: ciphertext.encryptedContent,
+      version: INTERNAL_TEST_VERSION,
+    })
+    // Assert
+    expect(decrypted).toHaveProperty('responses', plaintext)
+  })
+
+  // it('should be able to encrypt submissions without signing if signingPrivateKey is missing', () => {
+  //   // Arrange
+  //   const { publicKey, secretKey } = crypto.generate()
+
+  //   // Act
+  //   // Signing key (last parameter) is omitted.
+  //   const ciphertext = crypto.encrypt(plaintext, publicKey)
+  //   const decrypted = crypto.decrypt(secretKey, {
+  //     encryptedContent: ciphertext,
+  //     version: INTERNAL_TEST_VERSION,
+  //   })
+
+  //   // Assert
+  //   expect(decrypted).toHaveProperty('responses', plaintext)
+  // })
+
+  // it('should be able to encrypt and sign submissions if signingPrivateKey is given', () => {
+  //   // Arrange
+  //   const { publicKey, secretKey } = crypto.generate()
+
+  //   // Act
+  //   // Encrypt content that is not signed.
+  //   const ciphertext = crypto.encrypt(plaintext, publicKey)
+  //   // Sign and encrypt the desired content.
+  //   const signedAndEncryptedText = crypto.encrypt(
+  //     mockVerifiedContent,
+  //     publicKey,
+  //     signingSecretKey
+  //   )
+  //   // Decrypt encrypted content along with our signed+encrypted content.
+  //   const decrypted = crypto.decrypt(secretKey, {
+  //     encryptedContent: ciphertext,
+  //     verifiedContent: signedAndEncryptedText,
+  //     version: INTERNAL_TEST_VERSION,
+  //   })
+
+  //   // Assert
+  //   expect(decrypted).toHaveProperty('verified', mockVerifiedContent)
+  //   expect(decrypted).toHaveProperty('responses', plaintext)
+  // })
+
+  // it('should be able to encrypt and decrypt files end-to-end', async () => {
+  //   // Arrange
+  //   const { publicKey, secretKey } = crypto.generate()
+
+  //   // Act
+  //   // Encrypt
+  //   const encrypted = await crypto.encryptFile(testFileBuffer, publicKey)
+  //   expect(encrypted).toHaveProperty('submissionPublicKey')
+  //   expect(encrypted).toHaveProperty('nonce')
+  //   expect(encrypted).toHaveProperty('binary')
+
+  //   // Decrypt
+  //   const decrypted = await crypto.decryptFile(secretKey, encrypted)
+
+  //   if (!decrypted) {
+  //     throw new Error('File should be able to decrypt successfully.')
+  //   }
+
+  //   // Compare
+  //   expect(testFileBuffer).toEqual(decrypted)
+  // })
+
+  // it('should return null if file could not be decrypted', async () => {
+  //   const { publicKey, secretKey } = crypto.generate()
+
+  //   const encrypted = await crypto.encryptFile(testFileBuffer, publicKey)
+  //   // Rewrite binary with invalid Uint8Array.
+  //   encrypted.binary = new Uint8Array([1, 2])
+
+  //   const decrypted = await crypto.decryptFile(secretKey, encrypted)
+
+  //   expect(decrypted).toBeNull()
+  // })
+
+  // it('should throw error if class was not instantiated with a public signing key while verifying decrypted content ', () => {
+  //   // Arrange
+  //   const cryptoNoKey = new Crypto()
+  //   const { publicKey, secretKey } = cryptoNoKey.generate()
+
+  //   // Act
+  //   // Encrypt content that is not signed.
+  //   const ciphertext = cryptoNoKey.encrypt(plaintext, publicKey)
+  //   // Sign and encrypt the desired content.
+  //   const signedAndEncryptedText = cryptoNoKey.encrypt(
+  //     mockVerifiedContent,
+  //     publicKey,
+  //     signingSecretKey
+  //   )
+
+  //   // Assert
+  //   // Attempt to decrypt encrypted content along with our signed+encrypted
+  //   // content should throw an error
+  //   expect(() =>
+  //     cryptoNoKey.decrypt(secretKey, {
+  //       encryptedContent: ciphertext,
+  //       verifiedContent: signedAndEncryptedText,
+  //       version: INTERNAL_TEST_VERSION,
+  //     })
+  //   ).toThrow(MissingPublicKeyError)
+  // })
+
+  // it('should return null if decrypting encrypted verified content failed', () => {
+  //   // Arrange
+  //   const { publicKey, secretKey } = crypto.generate()
+  //   // Encrypt content that is not signed.
+  //   const ciphertext = crypto.encrypt(plaintext, publicKey)
+  //   // Create rubbish verified content
+  //   const rubbishVerifiedContent = 'abcdefg'
+
+  //   // Act + Assert
+  //   const decryptResult = crypto.decrypt(secretKey, {
+  //     encryptedContent: ciphertext,
+  //     verifiedContent: rubbishVerifiedContent,
+  //     version: INTERNAL_TEST_VERSION,
+  //   })
+  //   expect(decryptResult).toBeNull()
+  // })
+
+  // it('should be able to download and decrypt an attachment successfully', async () => {
+  //   // Arrange
+  //   const { publicKey, secretKey } = crypto.generate()
+
+  //   let attachmentPlaintext = plaintext.slice(0)
+  //   attachmentPlaintext.push({
+  //     _id: '6e771c946b3c5100240368e5',
+  //     question: 'Random file',
+  //     fieldType: 'attachment',
+  //     answer: 'my-random-file.txt',
+  //   })
+
+  //   // Encrypt content that is not signed
+  //   const ciphertext = crypto.encrypt(attachmentPlaintext, publicKey)
+
+  //   // Encrypt file
+  //   const encryptedFile = await crypto.encryptFile(testFileBuffer, publicKey)
+  //   const uploadedFile = {
+  //     submissionPublicKey: encryptedFile.submissionPublicKey,
+  //     nonce: encryptedFile.nonce,
+  //     binary: encodeBase64(encryptedFile.binary)
+  //   }
+
+  //   // Act
+  //   const decryptedFilesPromise = crypto.decryptWithAttachments(secretKey, {
+  //     encryptedContent: ciphertext,
+  //     attachmentDownloadUrls: { '6e771c946b3c5100240368e5': 'https://some.s3.url/some/encrypted/file' },
+  //     version: INTERNAL_TEST_VERSION,
+  //   })
+  //   mockAxios.mockResponse({ data: { encryptedFile: uploadedFile }})
+  //   const decryptedContentWithAttachments = await decryptedFilesPromise
+  //   const decryptedFiles = decryptedContentWithAttachments!.attachments
+
+  //   // Assert
+  //   expect(mockAxios.get).toHaveBeenCalledWith('https://some.s3.url/some/encrypted/file', { responseType: 'json' })
+  //   expect(decryptedFiles).toHaveProperty('6e771c946b3c5100240368e5', { filename: 'my-random-file.txt', content: testFileBuffer })
+  // })
+
+  // it('should be able to handle fields without attachmentDownloadUrls', async () => {
+  //   // Arrange
+  //   const { publicKey, secretKey } = crypto.generate()
+
+  //   // Encrypt content that is not signed
+  //   const ciphertext = crypto.encrypt(plaintext, publicKey)
+
+  //   // Act
+  //   const decryptedContentWithAttachments = await crypto.decryptWithAttachments(secretKey, {
+  //     encryptedContent: ciphertext,
+  //     version: INTERNAL_TEST_VERSION,
+  //   })
+  //   const decryptedFiles = decryptedContentWithAttachments!.attachments
+
+  //   // Assert
+  //   expect(decryptedFiles).toEqual({})
+  // })
+
+  // it('should be able to handle corrupted encrypted content', async () => {
+  //   // Arrange
+  //   const { secretKey } = crypto.generate()
+
+  //   // Act
+  //   const decryptedContents = await crypto.decryptWithAttachments(secretKey, {
+  //     encryptedContent: 'bad encrypted content',
+  //     version: INTERNAL_TEST_VERSION,
+  //   })
+
+  //   // Assert
+  //   expect(decryptedContents).toBe(null)
+  // })
+
+  // it('should be able to handle corrupted download', async () => {
+  //   // Arrange
+  //   const { publicKey, secretKey } = crypto.generate()
+
+  //   let attachmentPlaintext = plaintext.slice(0)
+  //   attachmentPlaintext.push({
+  //     _id: '6e771c946b3c5100240368e5',
+  //     question: 'Random file',
+  //     fieldType: 'attachment',
+  //     answer: 'my-random-file.txt',
+  //   })
+
+  //   // Encrypt content that is not signed
+  //   const ciphertext = crypto.encrypt(attachmentPlaintext, publicKey)
+
+  //   // Encrypt file
+  //   const encryptedFile = await crypto.encryptFile(testFileBuffer, publicKey)
+  //   const uploadedFile = {
+  //     submissionPublicKey: encryptedFile.submissionPublicKey,
+  //     nonce: encryptedFile.nonce,
+  //     binary: 'YmFkZW5jcnlwdGVkY29udGVudHM=',  // invalid data
+  //   }
+
+  //   // Act
+  //   const decryptedFilesPromise = crypto.decryptWithAttachments(secretKey, {
+  //     encryptedContent: ciphertext,
+  //     attachmentDownloadUrls: { '6e771c946b3c5100240368e5': 'https://some.s3.url/some/encrypted/file' },
+  //     version: INTERNAL_TEST_VERSION,
+  //   })
+  //   mockAxios.mockResponse({ data: { encryptedFile: uploadedFile }})
+  //   const decryptedContents = await decryptedFilesPromise
+
+  //   // Assert
+  //   expect(decryptedContents).toBe(null)
+  // })
+
+  // it('should be able to handle decrypted submission without corresponding attachment field', async () => {
+  //   // Arrange
+  //   const { publicKey, secretKey } = crypto.generate()
+
+  //   // Encrypt content that is not signed
+  //   // Note that plaintext doesn't have any attachment fields
+  //   const ciphertext = crypto.encrypt(plaintext, publicKey)
+
+  //   // Encrypt file
+  //   const encryptedFile = await crypto.encryptFile(testFileBuffer, publicKey)
+  //   const uploadedFile = {
+  //     submissionPublicKey: encryptedFile.submissionPublicKey,
+  //     nonce: encryptedFile.nonce,
+  //     binary: encodeBase64(encryptedFile.binary)
+  //   }
+
+  //   // Act
+  //   const decryptedFilesPromise = crypto.decryptWithAttachments(secretKey, {
+  //     encryptedContent: ciphertext,
+  //     attachmentDownloadUrls: { '6e771c946b3c5100240368e5': 'https://some.s3.url/some/encrypted/file' },
+  //     version: INTERNAL_TEST_VERSION,
+  //   })
+  //   const decryptedContents = await decryptedFilesPromise
+
+  //   // Assert
+  //   expect(decryptedContents).toBe(null)
+  // })
+
+  // it('should be able to handle axios errors', async () => {
+  //   // Arrange
+  //   const { publicKey, secretKey } = crypto.generate()
+
+  //   let attachmentPlaintext = plaintext.slice(0)
+  //   attachmentPlaintext.push({
+  //     _id: '6e771c946b3c5100240368e5',
+  //     question: 'Random file',
+  //     fieldType: 'attachment',
+  //     answer: 'my-random-file.txt',
+  //   })
+
+  //   // Encrypt content that is not signed
+  //   const ciphertext = crypto.encrypt(attachmentPlaintext, publicKey)
+
+  //   // Act
+  //   const decryptedFilesPromise = crypto.decryptWithAttachments(secretKey, {
+  //     encryptedContent: ciphertext,
+  //     attachmentDownloadUrls: { '6e771c946b3c5100240368e5': 'https://some.s3.url/some/encrypted/file' },
+  //     version: INTERNAL_TEST_VERSION,
+  //   })
+  //   mockAxios.mockResponse({
+  //     data: {},
+  //     status: 404,
+  //     statusText: 'Not Found',
+  //   })
+  //   const decryptedContents = await decryptedFilesPromise
+
+  //   // Assert
+  //   expect(mockAxios.get).toHaveBeenCalledWith('https://some.s3.url/some/encrypted/file', { responseType: 'json' })
+  //   expect(decryptedContents).toBe(null)
+  // })
+})

--- a/spec/crypto-v3.spec.ts
+++ b/spec/crypto-v3.spec.ts
@@ -1,10 +1,4 @@
 import mockAxios from 'jest-mock-axios'
-import { SIGNING_KEYS } from '../src/resource/signing-keys'
-
-import {
-  encodeBase64,
-} from 'tweetnacl-util'
-
 import {
   plaintext,
   ciphertext,
@@ -12,13 +6,10 @@ import {
   formSecretKey,
   submissionSecretKey
 } from './resources/crypto-v3-data-20231207'
-import { MissingPublicKeyError } from '../src/errors'
 import CryptoV3 from '../src/crypto-v3'
 
 const INTERNAL_TEST_VERSION = 3
 
-const encryptionPublicKey = SIGNING_KEYS.test.publicKey
-const signingSecretKey = SIGNING_KEYS.test.secretKey
 const testFileBuffer = new Uint8Array(Buffer.from('./resources/ogp.svg'))
 
 jest.mock('axios', () => mockAxios)
@@ -27,11 +18,6 @@ describe('CryptoV3', function () {
   afterEach(() => mockAxios.reset())
 
   const crypto = new CryptoV3()
-
-  const mockVerifiedContent = {
-    uinFin: 'S12345679Z',
-    somethingElse: 99,
-  }
 
   it('should generate a keypair', () => {
     const keypair = crypto.generate()
@@ -57,42 +43,31 @@ describe('CryptoV3', function () {
     expect(crypto.valid(publicKey, secretKey)).toBe(false)
   })
 
-  // it('should decrypt the submission ciphertext from 2020-03-22 successfully', () => {
-  //   // Act
-  //   const decrypted = crypto.decrypt(formSecretKey, {
-  //     encryptedContent: ciphertext,
-  //     version: INTERNAL_TEST_VERSION,
-  //   })
+  it('should return null on unsuccessful decryption from form secret key', () => {
+    expect(
+      crypto.decrypt('random', {
+        ...ciphertext,
+        version: INTERNAL_TEST_VERSION,
+      })
+    ).toBe(null)
+  })
 
-  //   // Assert
-  //   expect(decrypted).toHaveProperty('responses', plaintext)
-  // })
+  it('should return null when successfully decrypted content from form secret key does not fit FormFieldV3 type shape', () => {
+    // Arrange
+    const { publicKey, secretKey } = crypto.generate()
+    const malformedContent = 'just a string, not an object with FormField shape'
+    const malformedEncrypt = crypto.encrypt(malformedContent, publicKey)
 
-  // it('should return null on unsuccessful decryption', () => {
-  //   expect(
-  //     crypto.decrypt('random', {
-  //       encryptedContent: ciphertext,
-  //       version: INTERNAL_TEST_VERSION,
-  //     })
-  //   ).toBe(null)
-  // })
-
-  // it('should return null when successfully decrypted content does not fit FormField type shape', () => {
-  //   // Arrange
-  //   const { publicKey, secretKey } = crypto.generate()
-  //   const malformedContent = 'just a string, not an object with FormField shape'
-  //   const malformedEncrypt = crypto.encrypt(malformedContent, publicKey)
-
-  //   // Assert
-  //   // Using correct secret key, but the decrypted object should not fit the
-  //   // expected shape and thus return null.
-  //   expect(
-  //     crypto.decrypt(secretKey, {
-  //       encryptedContent: malformedEncrypt,
-  //       version: INTERNAL_TEST_VERSION,
-  //     })
-  //   ).toBe(null)
-  // })
+    // Assert
+    // Using correct secret key, but the decrypted object should not fit the
+    // expected shape and thus return null.
+    expect(
+      crypto.decrypt(secretKey, {
+        ...malformedEncrypt,
+        version: INTERNAL_TEST_VERSION,
+      })
+    ).toBe(null)
+  })
 
   it('should be able to encrypt and decrypt submissions from 2023-12-07 end-to-end successfully from the form private key', () => {
     // Arrange
@@ -118,289 +93,37 @@ describe('CryptoV3', function () {
     expect(decrypted).toHaveProperty('responses', plaintext)
   })
 
-  // it('should be able to encrypt submissions without signing if signingPrivateKey is missing', () => {
-  //   // Arrange
-  //   const { publicKey, secretKey } = crypto.generate()
+  it('should be able to encrypt and decrypt files end-to-end', async () => {
+    // Arrange
+    const { publicKey, secretKey } = crypto.generate()
 
-  //   // Act
-  //   // Signing key (last parameter) is omitted.
-  //   const ciphertext = crypto.encrypt(plaintext, publicKey)
-  //   const decrypted = crypto.decrypt(secretKey, {
-  //     encryptedContent: ciphertext,
-  //     version: INTERNAL_TEST_VERSION,
-  //   })
+    // Act
+    // Encrypt
+    const encrypted = await crypto.encryptFile(testFileBuffer, publicKey)
+    expect(encrypted).toHaveProperty('filePublicKey')
+    expect(encrypted).toHaveProperty('nonce')
+    expect(encrypted).toHaveProperty('binary')
 
-  //   // Assert
-  //   expect(decrypted).toHaveProperty('responses', plaintext)
-  // })
+    // Decrypt
+    const decrypted = await crypto.decryptFile(secretKey, encrypted)
 
-  // it('should be able to encrypt and sign submissions if signingPrivateKey is given', () => {
-  //   // Arrange
-  //   const { publicKey, secretKey } = crypto.generate()
+    if (!decrypted) {
+      throw new Error('File should be able to decrypt successfully.')
+    }
 
-  //   // Act
-  //   // Encrypt content that is not signed.
-  //   const ciphertext = crypto.encrypt(plaintext, publicKey)
-  //   // Sign and encrypt the desired content.
-  //   const signedAndEncryptedText = crypto.encrypt(
-  //     mockVerifiedContent,
-  //     publicKey,
-  //     signingSecretKey
-  //   )
-  //   // Decrypt encrypted content along with our signed+encrypted content.
-  //   const decrypted = crypto.decrypt(secretKey, {
-  //     encryptedContent: ciphertext,
-  //     verifiedContent: signedAndEncryptedText,
-  //     version: INTERNAL_TEST_VERSION,
-  //   })
+    // Compare
+    expect(testFileBuffer).toEqual(decrypted)
+  })
 
-  //   // Assert
-  //   expect(decrypted).toHaveProperty('verified', mockVerifiedContent)
-  //   expect(decrypted).toHaveProperty('responses', plaintext)
-  // })
+  it('should return null if file could not be decrypted', async () => {
+    const { publicKey, secretKey } = crypto.generate()
 
-  // it('should be able to encrypt and decrypt files end-to-end', async () => {
-  //   // Arrange
-  //   const { publicKey, secretKey } = crypto.generate()
+    const encrypted = await crypto.encryptFile(testFileBuffer, publicKey)
+    // Rewrite binary with invalid Uint8Array.
+    encrypted.binary = new Uint8Array([1, 2])
 
-  //   // Act
-  //   // Encrypt
-  //   const encrypted = await crypto.encryptFile(testFileBuffer, publicKey)
-  //   expect(encrypted).toHaveProperty('submissionPublicKey')
-  //   expect(encrypted).toHaveProperty('nonce')
-  //   expect(encrypted).toHaveProperty('binary')
+    const decrypted = await crypto.decryptFile(secretKey, encrypted)
 
-  //   // Decrypt
-  //   const decrypted = await crypto.decryptFile(secretKey, encrypted)
-
-  //   if (!decrypted) {
-  //     throw new Error('File should be able to decrypt successfully.')
-  //   }
-
-  //   // Compare
-  //   expect(testFileBuffer).toEqual(decrypted)
-  // })
-
-  // it('should return null if file could not be decrypted', async () => {
-  //   const { publicKey, secretKey } = crypto.generate()
-
-  //   const encrypted = await crypto.encryptFile(testFileBuffer, publicKey)
-  //   // Rewrite binary with invalid Uint8Array.
-  //   encrypted.binary = new Uint8Array([1, 2])
-
-  //   const decrypted = await crypto.decryptFile(secretKey, encrypted)
-
-  //   expect(decrypted).toBeNull()
-  // })
-
-  // it('should throw error if class was not instantiated with a public signing key while verifying decrypted content ', () => {
-  //   // Arrange
-  //   const cryptoNoKey = new Crypto()
-  //   const { publicKey, secretKey } = cryptoNoKey.generate()
-
-  //   // Act
-  //   // Encrypt content that is not signed.
-  //   const ciphertext = cryptoNoKey.encrypt(plaintext, publicKey)
-  //   // Sign and encrypt the desired content.
-  //   const signedAndEncryptedText = cryptoNoKey.encrypt(
-  //     mockVerifiedContent,
-  //     publicKey,
-  //     signingSecretKey
-  //   )
-
-  //   // Assert
-  //   // Attempt to decrypt encrypted content along with our signed+encrypted
-  //   // content should throw an error
-  //   expect(() =>
-  //     cryptoNoKey.decrypt(secretKey, {
-  //       encryptedContent: ciphertext,
-  //       verifiedContent: signedAndEncryptedText,
-  //       version: INTERNAL_TEST_VERSION,
-  //     })
-  //   ).toThrow(MissingPublicKeyError)
-  // })
-
-  // it('should return null if decrypting encrypted verified content failed', () => {
-  //   // Arrange
-  //   const { publicKey, secretKey } = crypto.generate()
-  //   // Encrypt content that is not signed.
-  //   const ciphertext = crypto.encrypt(plaintext, publicKey)
-  //   // Create rubbish verified content
-  //   const rubbishVerifiedContent = 'abcdefg'
-
-  //   // Act + Assert
-  //   const decryptResult = crypto.decrypt(secretKey, {
-  //     encryptedContent: ciphertext,
-  //     verifiedContent: rubbishVerifiedContent,
-  //     version: INTERNAL_TEST_VERSION,
-  //   })
-  //   expect(decryptResult).toBeNull()
-  // })
-
-  // it('should be able to download and decrypt an attachment successfully', async () => {
-  //   // Arrange
-  //   const { publicKey, secretKey } = crypto.generate()
-
-  //   let attachmentPlaintext = plaintext.slice(0)
-  //   attachmentPlaintext.push({
-  //     _id: '6e771c946b3c5100240368e5',
-  //     question: 'Random file',
-  //     fieldType: 'attachment',
-  //     answer: 'my-random-file.txt',
-  //   })
-
-  //   // Encrypt content that is not signed
-  //   const ciphertext = crypto.encrypt(attachmentPlaintext, publicKey)
-
-  //   // Encrypt file
-  //   const encryptedFile = await crypto.encryptFile(testFileBuffer, publicKey)
-  //   const uploadedFile = {
-  //     submissionPublicKey: encryptedFile.submissionPublicKey,
-  //     nonce: encryptedFile.nonce,
-  //     binary: encodeBase64(encryptedFile.binary)
-  //   }
-
-  //   // Act
-  //   const decryptedFilesPromise = crypto.decryptWithAttachments(secretKey, {
-  //     encryptedContent: ciphertext,
-  //     attachmentDownloadUrls: { '6e771c946b3c5100240368e5': 'https://some.s3.url/some/encrypted/file' },
-  //     version: INTERNAL_TEST_VERSION,
-  //   })
-  //   mockAxios.mockResponse({ data: { encryptedFile: uploadedFile }})
-  //   const decryptedContentWithAttachments = await decryptedFilesPromise
-  //   const decryptedFiles = decryptedContentWithAttachments!.attachments
-
-  //   // Assert
-  //   expect(mockAxios.get).toHaveBeenCalledWith('https://some.s3.url/some/encrypted/file', { responseType: 'json' })
-  //   expect(decryptedFiles).toHaveProperty('6e771c946b3c5100240368e5', { filename: 'my-random-file.txt', content: testFileBuffer })
-  // })
-
-  // it('should be able to handle fields without attachmentDownloadUrls', async () => {
-  //   // Arrange
-  //   const { publicKey, secretKey } = crypto.generate()
-
-  //   // Encrypt content that is not signed
-  //   const ciphertext = crypto.encrypt(plaintext, publicKey)
-
-  //   // Act
-  //   const decryptedContentWithAttachments = await crypto.decryptWithAttachments(secretKey, {
-  //     encryptedContent: ciphertext,
-  //     version: INTERNAL_TEST_VERSION,
-  //   })
-  //   const decryptedFiles = decryptedContentWithAttachments!.attachments
-
-  //   // Assert
-  //   expect(decryptedFiles).toEqual({})
-  // })
-
-  // it('should be able to handle corrupted encrypted content', async () => {
-  //   // Arrange
-  //   const { secretKey } = crypto.generate()
-
-  //   // Act
-  //   const decryptedContents = await crypto.decryptWithAttachments(secretKey, {
-  //     encryptedContent: 'bad encrypted content',
-  //     version: INTERNAL_TEST_VERSION,
-  //   })
-
-  //   // Assert
-  //   expect(decryptedContents).toBe(null)
-  // })
-
-  // it('should be able to handle corrupted download', async () => {
-  //   // Arrange
-  //   const { publicKey, secretKey } = crypto.generate()
-
-  //   let attachmentPlaintext = plaintext.slice(0)
-  //   attachmentPlaintext.push({
-  //     _id: '6e771c946b3c5100240368e5',
-  //     question: 'Random file',
-  //     fieldType: 'attachment',
-  //     answer: 'my-random-file.txt',
-  //   })
-
-  //   // Encrypt content that is not signed
-  //   const ciphertext = crypto.encrypt(attachmentPlaintext, publicKey)
-
-  //   // Encrypt file
-  //   const encryptedFile = await crypto.encryptFile(testFileBuffer, publicKey)
-  //   const uploadedFile = {
-  //     submissionPublicKey: encryptedFile.submissionPublicKey,
-  //     nonce: encryptedFile.nonce,
-  //     binary: 'YmFkZW5jcnlwdGVkY29udGVudHM=',  // invalid data
-  //   }
-
-  //   // Act
-  //   const decryptedFilesPromise = crypto.decryptWithAttachments(secretKey, {
-  //     encryptedContent: ciphertext,
-  //     attachmentDownloadUrls: { '6e771c946b3c5100240368e5': 'https://some.s3.url/some/encrypted/file' },
-  //     version: INTERNAL_TEST_VERSION,
-  //   })
-  //   mockAxios.mockResponse({ data: { encryptedFile: uploadedFile }})
-  //   const decryptedContents = await decryptedFilesPromise
-
-  //   // Assert
-  //   expect(decryptedContents).toBe(null)
-  // })
-
-  // it('should be able to handle decrypted submission without corresponding attachment field', async () => {
-  //   // Arrange
-  //   const { publicKey, secretKey } = crypto.generate()
-
-  //   // Encrypt content that is not signed
-  //   // Note that plaintext doesn't have any attachment fields
-  //   const ciphertext = crypto.encrypt(plaintext, publicKey)
-
-  //   // Encrypt file
-  //   const encryptedFile = await crypto.encryptFile(testFileBuffer, publicKey)
-  //   const uploadedFile = {
-  //     submissionPublicKey: encryptedFile.submissionPublicKey,
-  //     nonce: encryptedFile.nonce,
-  //     binary: encodeBase64(encryptedFile.binary)
-  //   }
-
-  //   // Act
-  //   const decryptedFilesPromise = crypto.decryptWithAttachments(secretKey, {
-  //     encryptedContent: ciphertext,
-  //     attachmentDownloadUrls: { '6e771c946b3c5100240368e5': 'https://some.s3.url/some/encrypted/file' },
-  //     version: INTERNAL_TEST_VERSION,
-  //   })
-  //   const decryptedContents = await decryptedFilesPromise
-
-  //   // Assert
-  //   expect(decryptedContents).toBe(null)
-  // })
-
-  // it('should be able to handle axios errors', async () => {
-  //   // Arrange
-  //   const { publicKey, secretKey } = crypto.generate()
-
-  //   let attachmentPlaintext = plaintext.slice(0)
-  //   attachmentPlaintext.push({
-  //     _id: '6e771c946b3c5100240368e5',
-  //     question: 'Random file',
-  //     fieldType: 'attachment',
-  //     answer: 'my-random-file.txt',
-  //   })
-
-  //   // Encrypt content that is not signed
-  //   const ciphertext = crypto.encrypt(attachmentPlaintext, publicKey)
-
-  //   // Act
-  //   const decryptedFilesPromise = crypto.decryptWithAttachments(secretKey, {
-  //     encryptedContent: ciphertext,
-  //     attachmentDownloadUrls: { '6e771c946b3c5100240368e5': 'https://some.s3.url/some/encrypted/file' },
-  //     version: INTERNAL_TEST_VERSION,
-  //   })
-  //   mockAxios.mockResponse({
-  //     data: {},
-  //     status: 404,
-  //     statusText: 'Not Found',
-  //   })
-  //   const decryptedContents = await decryptedFilesPromise
-
-  //   // Assert
-  //   expect(mockAxios.get).toHaveBeenCalledWith('https://some.s3.url/some/encrypted/file', { responseType: 'json' })
-  //   expect(decryptedContents).toBe(null)
-  // })
+    expect(decrypted).toBeNull()
+  })
 })

--- a/spec/resources/crypto-v3-data-20231207.ts
+++ b/spec/resources/crypto-v3-data-20231207.ts
@@ -1,0 +1,52 @@
+/**
+ * DO NOT MODIFY THE DATA BELOW.
+ *
+ * The below data represents a submission from 2023-12-07.
+ * It must remain unmodified to maintain strict backwards compatibility.
+ *
+ * If changes are necessary, create new test data instead.
+ */
+
+const plaintext = {
+  '5e7479a086eaf2002488a20e': {
+    fieldType: 'email',
+    answer: 'test@open.gov.sg',
+  },
+  '5e771c246b3c5100240368d8': {
+    fieldType: 'mobile',
+    answer: '+6598765432',
+  },
+  '5e7479a386eaf2002488a20f': {
+    fieldType: 'number',
+    answer: '123',
+  },
+  '5e771c8a6b3c5100240368e1': {
+    fieldType: 'radiobutton',
+    answer: { value: 'Option 1' },
+  },
+  '5e771c7a6b3c5100240368e0': {
+    fieldType: 'checkbox',
+    answer: { value: ['Option 2'], othersInput: 'Another answer' },
+  }
+}
+
+const ciphertext = {
+  encryptedContent:
+    'yUW5li4+IA9q2/n3ZS+5+wrXQ8mKGrFJ1KW9Kf/eRzc=;PgZE8+y8rBvssnqLnqjnnqHDW6PngYKK:eIEuOUQjf1YkQIulZ7bCKXIl6wByg644Ulk/LjhefmLzhkVmXbTxBJVKVG6YgV0ZMcG4JPUuQ+WOW+N1/AOyL/8DJqclX74kG6s0DNXIJixkqNZCnfZapulerR9XXKSfwBjpo1nK25KCg32F/ey2HypPcluGV19hWwgj80mlms7Ya7x1X5wcdttlGrzGEnNH2VEPXjzJZHqiV1TWoQGwxSZ753fpkHUkBeKFA1UkMHS5XYnWyYD48JpfpOAz0L2ti6RHQnQLSKUHscYVfAZt5OyUGqPFmhm2ulWdycNVp8HayQrpqeY8cdu8QsmZRdNCMfMFLahZCm6xKS+8GUrJWgJr64yaZpkxQS45uPb9zxC+G/u4FZhS/YsrjDTuIIwMGS0+qsNr4075yemFFAQHIpbhWZ9QlYrNq2TAolrVezeAw3AQ/nr4sz60dvqRahcse9x8oMxB7jA55OuxH5uk6PcCIAmEi+njr6Lgbcn2mtPMyk7kGcwjNzCL57b51RxJVi0ZqNXrS0FFepvzCK3IOEqKqrKGGK0qGqF4MFsH2wdq4RFkXjLMZk4u9ZWjIRjc',
+  encryptedSubmissionSecretKey:
+    'ywWDxb29guAgVK4yhLmLK19UKzLrfLAl65JzPDCVNz8=;/Q3WNg7Dk/tWBmpdUcST39zG16/Nyn8V:p1YqpiwEtOssq3yZUhZC1SgIYJcfJDmVFmgNwKf8D+YEqDzLaq5GShR7hTtTixtp',
+}
+
+const formPublicKey = 'ySgusViv6xdSIXELuGOq2L3Obp8xorT0Qilv+G4nHnM='
+const formSecretKey = 'Ngx1Kwpe8JXZUof/DCkkVduVmPSN4paqaKj5971Gq5c='
+const submissionPublicKey = '8JCuSlyJZ5N684o9TNdZLijtuORTlD/pbXiFwNf7Fhc='
+const submissionSecretKey = 'bIyKphcx5hiuBaJ4q5cwnXaFNY9Ofe5NQBqTEzf3zYA='
+
+export {
+  plaintext,
+  ciphertext,
+  formPublicKey,
+  formSecretKey,
+  submissionPublicKey,
+  submissionSecretKey
+}

--- a/src/crypto-base.ts
+++ b/src/crypto-base.ts
@@ -1,0 +1,9 @@
+import { generateKeypair } from './util/crypto'
+
+export default class CryptoBase {
+  /**
+   * Generates a new keypair for encryption.
+   * @returns The generated keypair.
+   */
+  generate = generateKeypair
+}

--- a/src/crypto-base.ts
+++ b/src/crypto-base.ts
@@ -1,4 +1,8 @@
+import nacl from 'tweetnacl'
+import { decodeBase64, encodeBase64 } from 'tweetnacl-util'
+
 import { generateKeypair } from './util/crypto'
+import { EncryptedFileContent } from './types'
 
 export default class CryptoBase {
   /**
@@ -6,4 +10,55 @@ export default class CryptoBase {
    * @returns The generated keypair.
    */
   generate = generateKeypair
+
+  /**
+   * Encrypt given binary file with a unique keypair for each submission.
+   * @param binary The file to encrypt, should be a blob that is converted to Uint8Array binary
+   * @param publicKey The base-64 encoded public key
+   * @returns Promise holding the encrypted file
+   * @throws error if any of the encrypt methods fail
+   */
+  encryptFile = async (
+    binary: Uint8Array,
+    publicKey: string
+  ): Promise<EncryptedFileContent> => {
+    const fileKeypair = this.generate()
+    const nonce = nacl.randomBytes(24)
+    return {
+      //! NOTE: submissionPublicKey here is a misnomer as a new keypair is generated per file.
+      // The naming is only retained for backward-compatibility purposes.
+      submissionPublicKey: fileKeypair.publicKey,
+      nonce: encodeBase64(nonce),
+      binary: nacl.box(
+        binary,
+        nonce,
+        decodeBase64(publicKey),
+        decodeBase64(fileKeypair.secretKey)
+      ),
+    }
+  }
+
+  /**
+   * Decrypt the given encrypted file content.
+   * @param secretKey Secret key as a base-64 string
+   * @param encrypted Object returned from encryptFile function
+   * @param encrypted.submissionPublicKey The file's public key as a base-64 string
+   * @param encrypted.nonce The nonce as a base-64 string
+   * @param encrypted.blob The encrypted file as a Blob object
+   */
+  decryptFile = async (
+    secretKey: string,
+    {
+      submissionPublicKey: filePublicKey,
+      nonce,
+      binary: encryptedBinary,
+    }: EncryptedFileContent
+  ): Promise<Uint8Array | null> => {
+    return nacl.box.open(
+      encryptedBinary,
+      decodeBase64(nonce),
+      decodeBase64(filePublicKey),
+      decodeBase64(secretKey)
+    )
+  }
 }

--- a/src/crypto-v3.ts
+++ b/src/crypto-v3.ts
@@ -56,7 +56,6 @@ export default class CryptoV3 extends CryptoBase {
    * @param decryptParams.encryptedContent The encrypted content encoded with base-64.
    * @param decryptParams.version The version of the payload.
    * @returns The decrypted content if successful. Else, null will be returned.
-   * @throws {MissingPublicKeyError} if a public key is not provided when instantiating this class and is needed for verifying signed content.
    */
   decryptFromSubmissionKey = (
     submissionSecretKey: string,
@@ -100,7 +99,6 @@ export default class CryptoV3 extends CryptoBase {
    * @param decryptParams.encryptedSubmissionSecretKey The encrypted submission secret key encoded with base-64.
    * @param decryptParams.version The version of the payload. Used to determine the decryption process to decrypt the content with.
    * @returns The decrypted content if successful. Else, null will be returned.
-   * @throws {MissingPublicKeyError} if a public key is not provided when instantiating this class and is needed for verifying signed content.
    */
   decrypt = (
     formSecretKey: string,

--- a/src/crypto-v3.ts
+++ b/src/crypto-v3.ts
@@ -1,4 +1,3 @@
-import nacl from 'tweetnacl'
 import {
   decodeBase64,
   decodeUTF8,
@@ -14,7 +13,6 @@ import {
   DecryptParams,
   DecryptParamsV3,
   EncryptedContentV3,
-  EncryptedFileContentV3,
   FormFieldsV3,
 } from './types'
 
@@ -140,52 +138,6 @@ export default class CryptoV3 extends CryptoBase {
         ...cipherResponse,
         version: internalValidationVersion,
       })?.responses.toString()
-    )
-  }
-
-  /**
-   * Encrypt given binary file with a unique keypair for each submission.
-   * @requires encrypt() must have been called prior to retrieve a { submissionPublicKey, submissionSecretKey } keypair
-   * @param binary The file to encrypt, should be a blob that is converted to Uint8Array binary
-   * @param submissionPublicKey The base-64 encoded submission public key
-   * @returns Promise holding the encrypted file
-   * @throws error if any of the encrypt methods fail
-   */
-  encryptFile = async (
-    binary: Uint8Array,
-    submissionPublicKey: string
-  ): Promise<EncryptedFileContentV3> => {
-    const fileKeypair = this.generate()
-    const nonce = nacl.randomBytes(24)
-    return {
-      filePublicKey: fileKeypair.publicKey,
-      nonce: encodeBase64(nonce),
-      binary: nacl.box(
-        binary,
-        nonce,
-        decodeBase64(submissionPublicKey),
-        decodeBase64(fileKeypair.secretKey)
-      ),
-    }
-  }
-
-  /**
-   * Decrypt the given encrypted file content.
-   * @param submissionSecretKey Secret key as a base-64 string
-   * @param encrypted Object returned from encryptFile function
-   * @param encrypted.filePublicKey The submission public key as a base-64 string
-   * @param encrypted.nonce The nonce as a base-64 string
-   * @param encrypted.blob The encrypted file as a Blob object
-   */
-  decryptFile = async (
-    submissionSecretKey: string,
-    { filePublicKey, nonce, binary: encryptedBinary }: EncryptedFileContentV3
-  ): Promise<Uint8Array | null> => {
-    return nacl.box.open(
-      encryptedBinary,
-      decodeBase64(nonce),
-      decodeBase64(filePublicKey),
-      decodeBase64(submissionSecretKey)
     )
   }
 }

--- a/src/crypto-v3.ts
+++ b/src/crypto-v3.ts
@@ -1,4 +1,9 @@
-import { decodeUTF8, encodeUTF8 } from 'tweetnacl-util'
+import {
+  decodeBase64,
+  decodeUTF8,
+  encodeBase64,
+  encodeUTF8,
+} from 'tweetnacl-util'
 
 import { decryptContent, encryptMessage } from './util/crypto'
 import { determineIsFormFieldsV3 } from './util/validate'
@@ -29,13 +34,12 @@ export default class CryptoV3 extends CryptoBase {
 
   /**
    * Encrypt input with a unique keypair for each key.
-   * @param k The key to encrypt as a string.
+   * @param k The base-64 encoded key to encrypt as a string.
    * @param formPublicKey The base-64 encoded public key for encrypting.
    * @returns The encrypted key string.
    */
   encryptKey = (k: string, formPublicKey: string): EncryptedContent => {
-    const processedMsg = decodeUTF8(k)
-    return encryptMessage(processedMsg, formPublicKey)
+    return encryptMessage(decodeBase64(k), formPublicKey)
   }
 
   /**
@@ -118,12 +122,12 @@ export default class CryptoV3 extends CryptoBase {
    * Decrypts an encrypted key and returns it.
    * @param formSecretKey The base-64 encoded secret key for decrypting.
    * @param ct The encrypted key encoded with base-64.
-   * @returns The decrypted content if successful. Else, null will be returned.
+   * @returns The decrypted key encoded with base-64 if successful. Else, null will be returned.
    */
   decryptKey = (formSecretKey: string, ct: string): string | null => {
     const decryptedContent = decryptContent(formSecretKey, ct)
     if (decryptedContent === null) return null
-    return encodeUTF8(decryptedContent)
+    return encodeBase64(decryptedContent)
   }
 
   /**

--- a/src/crypto-v3.ts
+++ b/src/crypto-v3.ts
@@ -111,6 +111,7 @@ export default class CryptoV3 extends CryptoBase {
 
       return returnedObject
     } catch (err) {
+      console.error(err)
       // Should only throw if MissingPublicKeyError.
       // This library should be able to be used to encrypt and decrypt content
       // if the content does not contain verified fields.
@@ -123,7 +124,7 @@ export default class CryptoV3 extends CryptoBase {
 
   /**
    * Decrypts an encrypted submission and returns it.
-   * @param form The base-64 encoded form secret key for decrypting the submission.
+   * @param formSecretKey The base-64 encoded form secret key for decrypting the submission.
    * @param decryptParams The params containing encrypted content, encrypted submission key and information.
    * @param decryptParams.encryptedContent The encrypted content encoded with base-64.
    * @param decryptParams.encryptedSubmissionSecretKey The encrypted submission secret key encoded with base-64.

--- a/src/crypto-v3.ts
+++ b/src/crypto-v3.ts
@@ -147,10 +147,10 @@ export default class CryptoV3 extends CryptoBase {
 
     throw new Error(`secretKey: ${encodeBase64(submissionSecretKey)}`)
 
-    return this.decryptFromSubmissionKey(
-      encodeBase64(submissionSecretKey),
-      rest
-    )
+    // return this.decryptFromSubmissionKey(
+    //   encodeBase64(submissionSecretKey),
+    //   rest
+    // )
   }
 
   /**

--- a/src/crypto-v3.ts
+++ b/src/crypto-v3.ts
@@ -1,3 +1,4 @@
+import nacl from 'tweetnacl'
 import {
   decodeBase64,
   decodeUTF8,
@@ -6,14 +7,13 @@ import {
 } from 'tweetnacl-util'
 
 import { decryptContent, encryptMessage, generateKeypair } from './util/crypto'
-import { determineIsFormFieldsV3 } from './util/validate'
 import CryptoBase from './crypto-base'
-import { MissingPublicKeyError } from './errors'
 import {
   DecryptedContentV3,
   DecryptParams,
   DecryptParamsV3,
   EncryptedContentV3,
+  EncryptedFileContentV3,
   FormFieldsV3,
 } from './types'
 
@@ -179,56 +179,49 @@ export default class CryptoV3 extends CryptoBase {
 
   /**
    * Encrypt given binary file with a unique keypair for each submission.
+   * @requires encrypt() must have been called prior to retrieve a { submissionPublicKey, submissionSecretKey } keypair
    * @param binary The file to encrypt, should be a blob that is converted to Uint8Array binary
-   * @param formPublicKey The base-64 encoded public key
+   * @param submissionPublicKey The base-64 encoded submission public key
    * @returns Promise holding the encrypted file
    * @throws error if any of the encrypt methods fail
    */
-  /*
   encryptFile = async (
     binary: Uint8Array,
-    formPublicKey: string
-  ): Promise<EncryptedFileContent> => {
-    const submissionKeypair = this.generate()
+    submissionPublicKey: string
+  ): Promise<EncryptedFileContentV3> => {
+    const fileKeypair = this.generate()
     const nonce = nacl.randomBytes(24)
     return {
-      submissionPublicKey: submissionKeypair.publicKey,
+      filePublicKey: fileKeypair.publicKey,
       nonce: encodeBase64(nonce),
       binary: nacl.box(
         binary,
         nonce,
-        decodeBase64(formPublicKey),
-        decodeBase64(submissionKeypair.secretKey)
+        decodeBase64(submissionPublicKey),
+        decodeBase64(fileKeypair.secretKey)
       ),
     }
   }
-  */
 
   /**
    * Decrypt the given encrypted file content.
-   * @param formSecretKey Secret key as a base-64 string
+   * @param submissionSecretKey Secret key as a base-64 string
    * @param encrypted Object returned from encryptFile function
-   * @param encrypted.submissionPublicKey The submission public key as a base-64 string
+   * @param encrypted.filePublicKey The submission public key as a base-64 string
    * @param encrypted.nonce The nonce as a base-64 string
    * @param encrypted.blob The encrypted file as a Blob object
    */
-  /*
   decryptFile = async (
-    formSecretKey: string,
-    {
-      submissionPublicKey,
-      nonce,
-      binary: encryptedBinary,
-    }: EncryptedFileContent
+    submissionSecretKey: string,
+    { filePublicKey, nonce, binary: encryptedBinary }: EncryptedFileContentV3
   ): Promise<Uint8Array | null> => {
     return nacl.box.open(
       encryptedBinary,
       decodeBase64(nonce),
-      decodeBase64(submissionPublicKey),
-      decodeBase64(formSecretKey)
+      decodeBase64(filePublicKey),
+      decodeBase64(submissionSecretKey)
     )
   }
-  */
 
   /**
    * Decrypts an encrypted submission, and also download and decrypt any attachments alongside it.

--- a/src/crypto-v3.ts
+++ b/src/crypto-v3.ts
@@ -17,10 +17,8 @@ import {
   FormFieldsV3,
 } from './types'
 
-export default class CryptoV3 extends CryptoBase {
-  constructor() {
-    super()
-  }
+export default class CryptoV3 {
+  generate = generateKeypair
 
   /**
    * Encrypt input with a unique keypair for each submission.
@@ -145,12 +143,10 @@ export default class CryptoV3 extends CryptoBase {
 
     if (submissionSecretKey === null) return null
 
-    throw new Error(`secretKey: ${encodeBase64(submissionSecretKey)}`)
-
-    // return this.decryptFromSubmissionKey(
-    //   encodeBase64(submissionSecretKey),
-    //   rest
-    // )
+    return this.decryptFromSubmissionKey(
+      encodeBase64(submissionSecretKey),
+      rest
+    )
   }
 
   /**

--- a/src/crypto-v3.ts
+++ b/src/crypto-v3.ts
@@ -59,30 +59,30 @@ export default class CryptoV3 extends CryptoBase {
     submissionSecretKey: string,
     decryptParams: DecryptParams
   ): DecryptedContentV3 | null => {
-    try {
-      const { encryptedContent, verifiedContent } = decryptParams
+    // try {
+    const { encryptedContent, verifiedContent } = decryptParams
 
-      // Do not return the transformed object in `_decrypt` function as a signed
-      // object is not encoded in UTF8 and is encoded in Base-64 instead.
-      const decryptedContent = decryptContent(
-        submissionSecretKey,
-        encryptedContent
-      )
-      if (!decryptedContent) {
-        throw new Error('Failed to decrypt content')
-      }
-      const decryptedObject: Record<string, unknown> = JSON.parse(
-        encodeUTF8(decryptedContent)
-      )
-      // if (!determineIsFormFieldsV3(decryptedObject)) {
-      //   throw new Error('Decrypted object does not fit expected shape')
-      // }
+    // Do not return the transformed object in `_decrypt` function as a signed
+    // object is not encoded in UTF8 and is encoded in Base-64 instead.
+    const decryptedContent = decryptContent(
+      submissionSecretKey,
+      encryptedContent
+    )
+    if (!decryptedContent) {
+      throw new Error('Failed to decrypt content')
+    }
+    const decryptedObject: Record<string, unknown> = JSON.parse(
+      encodeUTF8(decryptedContent)
+    )
+    // if (!determineIsFormFieldsV3(decryptedObject)) {
+    //   throw new Error('Decrypted object does not fit expected shape')
+    // }
 
-      const returnedObject: DecryptedContentV3 = {
-        responses: decryptedObject as FormFieldsV3,
-      }
+    const returnedObject: DecryptedContentV3 = {
+      responses: decryptedObject as FormFieldsV3,
+    }
 
-      /*
+    /*
       if (verifiedContent) {
         if (!this.signingPublicKey) {
           throw new MissingPublicKeyError(
@@ -109,17 +109,16 @@ export default class CryptoV3 extends CryptoBase {
       }
       */
 
-      return returnedObject
-    } catch (err) {
-      console.error(err)
-      // Should only throw if MissingPublicKeyError.
-      // This library should be able to be used to encrypt and decrypt content
-      // if the content does not contain verified fields.
-      if (err instanceof MissingPublicKeyError) {
-        throw err
-      }
-      return null
-    }
+    return returnedObject
+    // } catch (err) {
+    // Should only throw if MissingPublicKeyError.
+    // This library should be able to be used to encrypt and decrypt content
+    // if the content does not contain verified fields.
+    //   if (err instanceof MissingPublicKeyError) {
+    //     throw err
+    //   }
+    //   return null
+    // }
   }
 
   /**
@@ -143,6 +142,7 @@ export default class CryptoV3 extends CryptoBase {
       formSecretKey,
       encryptedSubmissionSecretKey
     )
+
     if (submissionSecretKey === null) return null
 
     return this.decryptFromSubmissionKey(

--- a/src/crypto-v3.ts
+++ b/src/crypto-v3.ts
@@ -145,6 +145,8 @@ export default class CryptoV3 extends CryptoBase {
 
     if (submissionSecretKey === null) return null
 
+    throw new Error(`secretKey: ${encodeBase64(submissionSecretKey)}`)
+
     return this.decryptFromSubmissionKey(
       encodeBase64(submissionSecretKey),
       rest

--- a/src/crypto-v3.ts
+++ b/src/crypto-v3.ts
@@ -43,8 +43,9 @@ export default class CryptoV3 extends CryptoBase {
     )
 
     return {
-      encryptedContent,
+      submissionPublicKey: submissionKeypair.publicKey,
       submissionSecretKey: submissionKeypair.secretKey,
+      encryptedContent,
       encryptedSubmissionSecretKey,
     }
   }

--- a/src/crypto-v3.ts
+++ b/src/crypto-v3.ts
@@ -40,7 +40,11 @@ export default class CryptoV3 {
       submissionKeypair.publicKey
     )
 
-    return { encryptedContent, encryptedSubmissionSecretKey }
+    return {
+      encryptedContent,
+      submissionSecretKey: submissionKeypair.secretKey,
+      encryptedSubmissionSecretKey,
+    }
   }
 
   /**
@@ -77,6 +81,7 @@ export default class CryptoV3 {
     // }
 
     const returnedObject: DecryptedContentV3 = {
+      submissionSecretKey,
       responses: decryptedObject as FormFieldsV3,
     }
 

--- a/src/crypto-v3.ts
+++ b/src/crypto-v3.ts
@@ -17,8 +17,10 @@ import {
   FormFieldsV3,
 } from './types'
 
-export default class CryptoV3 {
-  generate = generateKeypair
+export default class CryptoV3 extends CryptoBase {
+  constructor() {
+    super()
+  }
 
   /**
    * Encrypt input with a unique keypair for each submission.

--- a/src/crypto-v3.ts
+++ b/src/crypto-v3.ts
@@ -74,12 +74,12 @@ export default class CryptoV3 extends CryptoBase {
       const decryptedObject: Record<string, unknown> = JSON.parse(
         encodeUTF8(decryptedContent)
       )
-      if (!determineIsFormFieldsV3(decryptedObject)) {
-        throw new Error('Decrypted object does not fit expected shape')
-      }
+      // if (!determineIsFormFieldsV3(decryptedObject)) {
+      //   throw new Error('Decrypted object does not fit expected shape')
+      // }
 
       const returnedObject: DecryptedContentV3 = {
-        responses: decryptedObject,
+        responses: decryptedObject as FormFieldsV3,
       }
 
       /*

--- a/src/crypto.ts
+++ b/src/crypto.ts
@@ -12,10 +12,10 @@ import {
   convertEncryptedAttachmentToFileContent,
   decryptContent,
   encryptMessage,
-  generateKeypair,
   verifySignedMessage,
 } from './util/crypto'
 import { determineIsFormFields } from './util/validate'
+import CryptoBase from './crypto-base'
 import { AttachmentDecryptionError, MissingPublicKeyError } from './errors'
 import {
   DecryptedAttachments,
@@ -29,14 +29,13 @@ import {
   FormField,
 } from './types'
 
-export default class Crypto {
+export default class Crypto extends CryptoBase {
   signingPublicKey?: string
 
   constructor({ signingPublicKey }: { signingPublicKey?: string } = {}) {
+    super()
     this.signingPublicKey = signingPublicKey
   }
-
-  generate = generateKeypair
 
   /**
    * Encrypt input with a unique keypair for each submission

--- a/src/crypto.ts
+++ b/src/crypto.ts
@@ -12,10 +12,10 @@ import {
   convertEncryptedAttachmentToFileContent,
   decryptContent,
   encryptMessage,
+  generateKeypair,
   verifySignedMessage,
 } from './util/crypto'
 import { determineIsFormFields } from './util/validate'
-import CryptoBase from './crypto-base'
 import { AttachmentDecryptionError, MissingPublicKeyError } from './errors'
 import {
   DecryptedAttachments,
@@ -29,13 +29,14 @@ import {
   FormField,
 } from './types'
 
-export default class Crypto extends CryptoBase {
+export default class Crypto {
   signingPublicKey?: string
 
   constructor({ signingPublicKey }: { signingPublicKey?: string } = {}) {
-    super()
     this.signingPublicKey = signingPublicKey
   }
+
+  generate = generateKeypair
 
   /**
    * Encrypt input with a unique keypair for each submission

--- a/src/crypto.ts
+++ b/src/crypto.ts
@@ -1,11 +1,6 @@
 import axios from 'axios'
 import nacl from 'tweetnacl'
-import {
-  decodeBase64,
-  decodeUTF8,
-  encodeBase64,
-  encodeUTF8,
-} from 'tweetnacl-util'
+import { decodeBase64, decodeUTF8, encodeUTF8 } from 'tweetnacl-util'
 
 import {
   areAttachmentFieldIdsValid,
@@ -25,7 +20,6 @@ import {
   EncryptedAttachmentContent,
   EncryptedAttachmentRecords,
   EncryptedContent,
-  EncryptedFileContent,
   FormField,
 } from './types'
 
@@ -146,55 +140,6 @@ export default class Crypto extends CryptoBase {
         encryptedContent: cipherResponse,
         version: internalValidationVersion,
       })?.responses.toString()
-    )
-  }
-
-  /**
-   * Encrypt given binary file with a unique keypair for each submission.
-   * @param binary The file to encrypt, should be a blob that is converted to Uint8Array binary
-   * @param formPublicKey The base-64 encoded public key
-   * @returns Promise holding the encrypted file
-   * @throws error if any of the encrypt methods fail
-   */
-  encryptFile = async (
-    binary: Uint8Array,
-    formPublicKey: string
-  ): Promise<EncryptedFileContent> => {
-    const submissionKeypair = this.generate()
-    const nonce = nacl.randomBytes(24)
-    return {
-      submissionPublicKey: submissionKeypair.publicKey,
-      nonce: encodeBase64(nonce),
-      binary: nacl.box(
-        binary,
-        nonce,
-        decodeBase64(formPublicKey),
-        decodeBase64(submissionKeypair.secretKey)
-      ),
-    }
-  }
-
-  /**
-   * Decrypt the given encrypted file content.
-   * @param formSecretKey Secret key as a base-64 string
-   * @param encrypted Object returned from encryptFile function
-   * @param encrypted.submissionPublicKey The submission public key as a base-64 string
-   * @param encrypted.nonce The nonce as a base-64 string
-   * @param encrypted.blob The encrypted file as a Blob object
-   */
-  decryptFile = async (
-    formSecretKey: string,
-    {
-      submissionPublicKey,
-      nonce,
-      binary: encryptedBinary,
-    }: EncryptedFileContent
-  ): Promise<Uint8Array | null> => {
-    return nacl.box.open(
-      encryptedBinary,
-      decodeBase64(nonce),
-      decodeBase64(submissionPublicKey),
-      decodeBase64(formSecretKey)
     )
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,6 @@
 import { getSigningPublicKey, getVerificationPublicKey } from './util/publicKey'
 import Crypto from './crypto'
+import CryptoV3 from './crypto-v3'
 import { PackageInitParams } from './types'
 import Verification from './verification'
 import Webhooks from './webhooks'
@@ -30,6 +31,7 @@ export = function (config: PackageInitParams = {}) {
       secretKey: webhookSecretKey,
     }),
     crypto: new Crypto({ signingPublicKey }),
+    cryptoV3: new CryptoV3(),
     verification: new Verification({
       publicKey: verificationPublicKey,
       secretKey: verificationOptions?.secretKey,

--- a/src/types.ts
+++ b/src/types.ts
@@ -26,6 +26,11 @@ export type FieldType =
   | 'date'
   | 'mobile'
   | 'homeno'
+  | 'statement'
+  | 'image'
+  | 'country_region'
+  | 'uen'
+  | 'children'
 
 // Represents form field responses in a form.
 export type FormField = {
@@ -38,6 +43,15 @@ export type FormField = {
   | { answer: string; answerArray?: never }
   | { answer?: never; answerArray: string[] | string[][] }
 )
+
+// Represents form field responses in a form.
+export type FormFieldsV3 = Record<
+  string,
+  {
+    fieldType: FieldType
+    answer: any // too complex to represent here
+  }
+>
 
 // Encrypted basestring containing the submission public key,
 // nonce and encrypted data in base-64.
@@ -59,6 +73,11 @@ export interface DecryptParams {
 export type DecryptedContent = {
   responses: FormField[]
   verified?: Record<string, any>
+}
+
+export type DecryptedContentV3 = {
+  responses: FormFieldsV3
+  // verified?: Record<string, any>
 }
 
 export type DecryptedFile = {

--- a/src/types.ts
+++ b/src/types.ts
@@ -91,7 +91,6 @@ export type DecryptedContent = {
 export type DecryptedContentV3 = {
   submissionSecretKey: string
   responses: FormFieldsV3
-  // verified?: Record<string, any>
 }
 
 export type DecryptedFile = {
@@ -109,12 +108,6 @@ export type DecryptedContentAndAttachments = {
 
 export type EncryptedFileContent = {
   submissionPublicKey: string
-  nonce: string
-  binary: Uint8Array
-}
-
-export type EncryptedFileContentV3 = {
-  filePublicKey: string
   nonce: string
   binary: Uint8Array
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -115,6 +115,12 @@ export type EncryptedFileContent = {
   binary: Uint8Array
 }
 
+export type EncryptedFileContentV3 = {
+  filePublicKey: string
+  nonce: string
+  binary: Uint8Array
+}
+
 export type EncryptedAttachmentContent = {
   encryptedFile: {
     submissionPublicKey: string

--- a/src/types.ts
+++ b/src/types.ts
@@ -81,8 +81,6 @@ export interface DecryptParamsV3 {
   encryptedContent: EncryptedContent
   encryptedSubmissionSecretKey: EncryptedContent
   version: number
-  verifiedContent?: EncryptedContent
-  attachmentDownloadUrls?: EncryptedAttachmentRecords
 }
 
 export type DecryptedContent = {

--- a/src/types.ts
+++ b/src/types.ts
@@ -61,6 +61,7 @@ export type EncryptedContent = string
 
 export type EncryptedContentV3 = {
   encryptedContent: EncryptedContent
+  submissionSecretKey: string
   encryptedSubmissionSecretKey: EncryptedContent
 }
 
@@ -89,6 +90,7 @@ export type DecryptedContent = {
 }
 
 export type DecryptedContentV3 = {
+  submissionSecretKey: string
   responses: FormFieldsV3
   // verified?: Record<string, any>
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -59,12 +59,25 @@ export type FormFieldsV3 = Record<
 // <SubmissionPublicKey>;<Base64Nonce>:<Base64EncryptedData>
 export type EncryptedContent = string
 
+export type EncryptedContentV3 = {
+  encryptedContent: EncryptedContent
+  encryptedSubmissionSecretKey: EncryptedContent
+}
+
 // Records containing a map of field IDs to URLs where encrypted
 // attachments can be downloaded.
 export type EncryptedAttachmentRecords = Record<string, string>
 
 export interface DecryptParams {
   encryptedContent: EncryptedContent
+  version: number
+  verifiedContent?: EncryptedContent
+  attachmentDownloadUrls?: EncryptedAttachmentRecords
+}
+
+export interface DecryptParamsV3 {
+  encryptedContent: EncryptedContent
+  encryptedSubmissionSecretKey: EncryptedContent
   version: number
   verifiedContent?: EncryptedContent
   attachmentDownloadUrls?: EncryptedAttachmentRecords

--- a/src/types.ts
+++ b/src/types.ts
@@ -60,8 +60,9 @@ export type FormFieldsV3 = Record<
 export type EncryptedContent = string
 
 export type EncryptedContentV3 = {
-  encryptedContent: EncryptedContent
+  submissionPublicKey: string
   submissionSecretKey: string
+  encryptedContent: EncryptedContent
   encryptedSubmissionSecretKey: EncryptedContent
 }
 

--- a/src/util/crypto.ts
+++ b/src/util/crypto.ts
@@ -54,18 +54,18 @@ export const decryptContent = (
   formPrivateKey: string,
   encryptedContent: EncryptedContent
 ): Uint8Array | null => {
-  // try {
-  const [submissionPublicKey, nonceEncrypted] = encryptedContent.split(';')
-  const [nonce, encrypted] = nonceEncrypted.split(':').map(decodeBase64)
-  return nacl.box.open(
-    encrypted,
-    nonce,
-    decodeBase64(submissionPublicKey),
-    decodeBase64(formPrivateKey)
-  )
-  // } catch (err) {
-  //   return null
-  // }
+  try {
+    const [submissionPublicKey, nonceEncrypted] = encryptedContent.split(';')
+    const [nonce, encrypted] = nonceEncrypted.split(':').map(decodeBase64)
+    return nacl.box.open(
+      encrypted,
+      nonce,
+      decodeBase64(submissionPublicKey),
+      decodeBase64(formPrivateKey)
+    )
+  } catch (err) {
+    return null
+  }
 }
 
 /**

--- a/src/util/crypto.ts
+++ b/src/util/crypto.ts
@@ -54,18 +54,18 @@ export const decryptContent = (
   formPrivateKey: string,
   encryptedContent: EncryptedContent
 ): Uint8Array | null => {
-  try {
-    const [submissionPublicKey, nonceEncrypted] = encryptedContent.split(';')
-    const [nonce, encrypted] = nonceEncrypted.split(':').map(decodeBase64)
-    return nacl.box.open(
-      encrypted,
-      nonce,
-      decodeBase64(submissionPublicKey),
-      decodeBase64(formPrivateKey)
-    )
-  } catch (err) {
-    return null
-  }
+  // try {
+  const [submissionPublicKey, nonceEncrypted] = encryptedContent.split(';')
+  const [nonce, encrypted] = nonceEncrypted.split(':').map(decodeBase64)
+  return nacl.box.open(
+    encrypted,
+    nonce,
+    decodeBase64(submissionPublicKey),
+    decodeBase64(formPrivateKey)
+  )
+  // } catch (err) {
+  //   return null
+  // }
 }
 
 /**

--- a/src/util/crypto.ts
+++ b/src/util/crypto.ts
@@ -2,10 +2,10 @@ import nacl from 'tweetnacl'
 import { decodeBase64, encodeBase64, encodeUTF8 } from 'tweetnacl-util'
 
 import {
-  Keypair,
-  EncryptedContent,
   EncryptedAttachmentContent,
+  EncryptedContent,
   EncryptedFileContent,
+  Keypair,
 } from '../types'
 
 /**

--- a/src/util/validate.ts
+++ b/src/util/validate.ts
@@ -24,6 +24,7 @@ function determineIsFormFields(tbd: any): tbd is FormField[] {
   return filter.length === tbd.length
 }
 
+// TODO(MRF): This is currently very rudimentary, we should look at making this more specific where required.
 function determineIsFormFieldsV3(tbd: any): tbd is FormFieldsV3 {
   for (const id of Object.keys(tbd)) {
     const value = tbd[id]

--- a/src/util/validate.ts
+++ b/src/util/validate.ts
@@ -1,4 +1,4 @@
-import { FormField } from '../types'
+import { FormField, FormFieldsV3 } from '../types'
 
 function determineIsFormFields(tbd: any): tbd is FormField[] {
   if (!Array.isArray(tbd)) {
@@ -24,4 +24,13 @@ function determineIsFormFields(tbd: any): tbd is FormField[] {
   return filter.length === tbd.length
 }
 
-export { determineIsFormFields }
+function determineIsFormFieldsV3(tbd: any): tbd is FormFieldsV3 {
+  for (const id of Object.keys(tbd)) {
+    const value = tbd[id]
+    const hasCorrectShape = value.fieldType && value.answer !== undefined
+    if (!hasCorrectShape) return false
+  }
+  return true
+}
+
+export { determineIsFormFields, determineIsFormFieldsV3 }


### PR DESCRIPTION
## Problem

We want to implement multi-respondent forms. This PR implements the crypto primitives required to encrypt and decrypt multi-respondent form responses.

## Solution

A new Crypto class, `CryptoV3` is written to support the new encryption scheme. Common functions between `Crypto` and `CryptoV3` are split into a `CryptoBase` parent class, which `Crypto` and `CryptoV3` now inherit.

**Breaking Changes** 
- No - this PR is backwards compatible  
