### PR TITLE
chore(workflow): explicitly set permissions on workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,6 @@
 name: CI
+permissions:
+  contents: read
 on:
   push:
   pull_request:


### PR DESCRIPTION
Potential fix for [https://github.com/opengovsg/formsg-javascript-sdk/security/code-scanning/6](https://github.com/opengovsg/formsg-javascript-sdk/security/code-scanning/6)

To fix the problem, we should explicitly set a restrictive `permissions` block in the workflow configuration. The best approach is to add a `permissions:` block at the top-level of the workflow configuration (after `name:` and before `on:` or after `on:` and before `jobs:`). This will apply to all jobs unless a job-specific block is set. For typical CI workflows like this, `contents: read` is sufficient, as the jobs only check out code and interact with packages, not with repository contents in a write capacity. If future jobs require more, they can override at the job level.

The only change required is adding the following at the root of `.github/workflows/ci.yml`:

```yaml
permissions:
  contents: read
```

No additional methods, imports, or definitions are necessary.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
